### PR TITLE
Set qingyun_city default

### DIFF
--- a/tests/unit/test_game_state.py
+++ b/tests/unit/test_game_state.py
@@ -1,0 +1,19 @@
+# test_game_state.py
+"""测试 GameState 默认值"""
+
+import sys
+from pathlib import Path
+
+# 添加项目根目录到Python路径
+project_root = Path(__file__).parent
+sys.path.insert(0, str(project_root))
+
+from xwe.core.game_core import GameState
+
+
+def test_game_state_default_location():
+    """GameState.from_dict 默认位置应为 qingyun_city"""
+    print("=== 测试 GameState 默认位置 ===")
+    state = GameState.from_dict({})
+    print(f"默认位置: {state.current_location}")
+    assert state.current_location == "qingyun_city"

--- a/xwe/core/game_core.py
+++ b/xwe/core/game_core.py
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
 class GameState:
     """游戏状态"""
     player: Optional[Character] = None
-    current_location: str = "青云城"
+    current_location: str = "qingyun_city"
     current_combat: Optional[str] = None
     game_time: int = 0  # 游戏时间（回合数）
     flags: Dict[str, Any] = field(default_factory=dict)
@@ -66,7 +66,7 @@ class GameState:
             # TODO: 实现Character.from_dict
             pass
         
-        state.current_location = data.get('current_location', '青云城')
+        state.current_location = data.get('current_location', 'qingyun_city')
         state.current_combat = data.get('current_combat')
         state.game_time = data.get('game_time', 0)
         state.flags = data.get('flags', {})


### PR DESCRIPTION
## Summary
- use `qingyun_city` as default location id
- adapt GameState loader to match new default
- add unit test covering the default location

## Testing
- `pytest -q tests/unit/test_game_state.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68425d9f877c832882c4c5c52bc0003f