### PR TITLE
Fix missing python-dotenv dependency

### DIFF
--- a/archive/deprecated/run_optimized_game.py
+++ b/archive/deprecated/run_optimized_game.py
@@ -6,7 +6,7 @@
 import sys
 import os
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
-from dotenv import load_dotenv
+from xwe.utils.dotenv_helper import load_dotenv
 
 # 加载环境变量
 load_dotenv()

--- a/main.py
+++ b/main.py
@@ -10,7 +10,7 @@ import sys
 import logging
 import time
 from pathlib import Path
-from dotenv import load_dotenv
+from xwe.utils.dotenv_helper import load_dotenv
 load_dotenv()
 
 
@@ -19,7 +19,6 @@ project_root = Path(__file__).parent
 sys.path.insert(0, str(project_root))
 
 from xwe.core import GameCore
-from dotenv import load_dotenv
 load_dotenv()  # 默认自动查找项目根目录的 .env 文件并加载
 
 # 配置日志

--- a/main_enhanced.py
+++ b/main_enhanced.py
@@ -28,7 +28,7 @@ from xwe.features import (
 )
 from xwe.features import HtmlGameLogger
 from xwe.features.visual_enhancement import TextAnimation, ProgressBar
-from dotenv import load_dotenv
+from xwe.utils.dotenv_helper import load_dotenv
 load_dotenv()
 
 # 配置日志

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,6 @@
-from dotenv import load_dotenv
+"""Test suite initialization helpers."""
+
+from xwe.utils.dotenv_helper import load_dotenv
 
 load_dotenv()
 

--- a/xwe/core/nlp/__init__.py
+++ b/xwe/core/nlp/__init__.py
@@ -1,4 +1,4 @@
-from dotenv import load_dotenv
+from xwe.utils.dotenv_helper import load_dotenv
 
 load_dotenv()
 # nlp/__init__.py

--- a/xwe/tests/__init__.py
+++ b/xwe/tests/__init__.py
@@ -1,4 +1,6 @@
-from dotenv import load_dotenv
+"""Internal test helpers for XWE."""
+
+from xwe.utils.dotenv_helper import load_dotenv
 
 load_dotenv()
 # tests

--- a/xwe/utils/dotenv_helper.py
+++ b/xwe/utils/dotenv_helper.py
@@ -1,0 +1,14 @@
+from typing import Optional
+
+
+def load_dotenv(dotenv_path: Optional[str] = None) -> None:
+    """Load environment variables from a .env file.
+
+    Tries to use ``python-dotenv`` if available; otherwise falls back to the
+    simplified implementation in ``dotenv_backup.py``.
+    """
+    try:
+        from dotenv import load_dotenv as _load
+    except Exception:
+        from dotenv_backup import load_dotenv as _load  # type: ignore
+    _load(dotenv_path)


### PR DESCRIPTION
## Summary
- add `dotenv_helper` with graceful fallback
- use fallback loader across the codebase
- update tests to import the helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842fbac04b483289fb42bfe70c2fba0