### PR TITLE
Fix excessive refresh in enhanced web UI

### DIFF
--- a/run_web_ui_enhanced.py
+++ b/run_web_ui_enhanced.py
@@ -85,6 +85,11 @@ class GameManager:
     def flush_output(self):
         """刷新游戏输出到日志"""
         output_lines = self.game.get_output()
+        if not output_lines:
+            # 日志已刷新完毕，清除刷新标记
+            self.state_changed = False
+            return
+
         for line in output_lines:
             # 解析日志类型
             log_type = "normal"
@@ -102,8 +107,11 @@ class GameManager:
                 log_type = "warning"
             elif "➤" in line:
                 log_type = "player"
-            
+
             self.add_log(line, log_type)
+
+        # 有新日志时标记需要刷新
+        self.state_changed = True
     
     def process_command(self, command):
         """处理命令"""


### PR DESCRIPTION
## Summary
- reduce polling noise by clearing refresh flag when no new logs

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68438ffc92c88328bb02562ef5adf84f