### PR TITLE
Improve UI log sync and randomize start message

### DIFF
--- a/run_web_ui_enhanced.py
+++ b/run_web_ui_enhanced.py
@@ -6,6 +6,7 @@ import threading
 import webbrowser
 import json
 import time
+import random
 from flask import Flask, render_template, request, jsonify, session
 from pathlib import Path
 import os
@@ -65,8 +66,13 @@ class GameManager:
         # 添加事件回调
         self.event_system.register_callback('first_cultivation_event', self._on_first_cultivation)
         
-        # 初始日志
-        self.add_log("【系统】正在唤醒修仙世界，请稍候……")
+        # 初始日志 - 随机欢迎语
+        opening_lines = [
+            "【系统】你凝视着星辰大海，命运悄然苏醒……",
+            "【系统】灵气浮动，天地将变，你的故事开始了。",
+            "【系统】青云山下，凡心未灭；今朝入道，一念永恒。"
+        ]
+        self.add_log(random.choice(opening_lines))
     
     def add_log(self, message, log_type="system"):
         """添加日志"""
@@ -85,6 +91,11 @@ class GameManager:
     def flush_output(self):
         """刷新游戏输出到日志"""
         output_lines = self.game.get_output()
+        if not output_lines:
+            # 日志已刷新完毕，清除刷新标记
+            self.state_changed = False
+            return
+
         for line in output_lines:
             # 解析日志类型
             log_type = "normal"
@@ -102,8 +113,11 @@ class GameManager:
                 log_type = "warning"
             elif "➤" in line:
                 log_type = "player"
-            
+
             self.add_log(line, log_type)
+
+        # 有新日志时标记需要刷新
+        self.state_changed = True
     
     def process_command(self, command):
         """处理命令"""

--- a/templates_enhanced/game_enhanced.html
+++ b/templates_enhanced/game_enhanced.html
@@ -1024,29 +1024,26 @@
                 const res = await fetch('/log');
                 const data = await res.json();
                 const log = document.getElementById('narrative-log');
-                
-                // 只添加新日志，避免重复
-                const currentLogs = log.querySelectorAll('.log-entry').length;
-                if (data.logs.length > currentLogs) {
-                    data.logs.slice(currentLogs).forEach(text => {
-                        // 解析日志类型
-                        let className = 'log-entry';
-                        if (text.startsWith('【系统】')) className += ' msg-system';
-                        else if (text.startsWith('【剧情】')) className += ' msg-event';
-                        else if (text.startsWith('【战斗】')) className += ' msg-combat';
-                        else if (text.startsWith('【奖励】')) className += ' msg-reward';
-                        else if (text.startsWith('[提示]')) className += ' msg-tip';
-                        else if (text.startsWith('【警告】')) className += ' msg-warning';
-                        else if (text.startsWith('➤')) className += ' msg-player';
-                        
-                        const entry = document.createElement('div');
-                        entry.className = className;
-                        entry.textContent = text;
-                        log.appendChild(entry);
-                    });
-                    
-                    log.scrollTop = log.scrollHeight;
-                }
+
+                // 重建日志列表，避免因数量限制导致的缺失
+                log.innerHTML = '';
+                data.logs.forEach(text => {
+                    let className = 'log-entry';
+                    if (text.startsWith('【系统】')) className += ' msg-system';
+                    else if (text.startsWith('【剧情】')) className += ' msg-event';
+                    else if (text.startsWith('【战斗】')) className += ' msg-combat';
+                    else if (text.startsWith('【奖励】')) className += ' msg-reward';
+                    else if (text.startsWith('[提示]')) className += ' msg-tip';
+                    else if (text.startsWith('【警告】')) className += ' msg-warning';
+                    else if (text.startsWith('➤')) className += ' msg-player';
+
+                    const entry = document.createElement('div');
+                    entry.className = className;
+                    entry.textContent = text;
+                    log.appendChild(entry);
+                });
+
+                log.scrollTop = log.scrollHeight;
             } catch (e) {
                 console.error('获取日志失败:', e);
             }
@@ -1205,7 +1202,7 @@
             updateAchievementDisplay();
             
             // 定期检查更新
-            setInterval(checkUpdates, 2000);
+            setInterval(checkUpdates, 3000);
             
             // 定期随机事件
             setInterval(() => {


### PR DESCRIPTION
## Summary
- randomize the opening lines on game start
- rebuild the log list on every refresh to avoid missing entries
- check updates less often to reduce server polling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68438ffc92c88328bb02562ef5adf84f