### PR TITLE
Fix missing jsonschema module

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ git clone <repository-url>
 cd xianxia_world_engine
 
 # 2. 安装依赖
-pip install -r requirements.txt
+pip install -r requirements.txt  # 包含 jsonschema 等核心库
 # 若需要完整的远程API功能，可单独安装 requests（或将 vendor 目录加入 PYTHONPATH）：
 pip install requests
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ Flask>=2.0.0
 # 核心依赖
 requests>=2.31.0  # 用于调用LLM API
 psutil>=5.9.0     # 用于系统监控和性能分析
+jsonschema>=4.0.0 # 用于配置数据验证
 
 # Python版本要求
 # Python >= 3.8


### PR DESCRIPTION
## Summary
- add jsonschema as a dependency
- note jsonschema requirement in README

## Testing
- `pip install -r requirements.txt`
- `pytest tests/ -v`

------
https://chatgpt.com/codex/tasks/task_e_6844716c14c4832887b27d7c02bfce30