### PR TITLE
Fix missing command handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ git clone <repository-url>
 cd xianxia_world_engine
 
 # 2. 安装依赖
-pip install -r requirements.txt
+pip install -r requirements.txt  # 包含 jsonschema 等核心库
 # 若需要完整的远程API功能，可单独安装 requests（或将 vendor 目录加入 PYTHONPATH）：
 pip install requests
 

--- a/README_V3.md
+++ b/README_V3.md
@@ -7,6 +7,11 @@
 python run_v3.py
 ```
 
+### 以 Web UI 启动
+```bash
+python run_web_ui_v3.py
+```
+
 ### 其他选项
 ```bash
 # 仅运行测试

--- a/docs/STARTERS.md
+++ b/docs/STARTERS.md
@@ -9,6 +9,7 @@
 | `python main.py` | 直接运行命令行版本游戏 |
 | `python main_enhanced.py` | 含 2.0 功能的增强版，生成 `game_log.html` |
 | `python run_web_ui.py` | 启动实验性的 Web 界面 |
+| `python run_web_ui_v3.py` | 使用数据驱动引擎的 Web 界面 |
 | `python start_enhanced_ui.py` | 启动增强版 Web UI（推荐） |
 | `python run_web_ui_enhanced.py` | 直接运行增强版 Web UI，跳过修复步骤 |
 | `python scripts/play_demo.py` | 带使用提示的演示版本 |

--- a/main_v3_data_driven.py
+++ b/main_v3_data_driven.py
@@ -291,6 +291,17 @@ class DataDrivenGameCore(GameCoreEnhanced):
         ]
         
         return "\n".join(output)
+
+    def handle_command(self, command: str, args: list) -> str:
+        """通过基础引擎处理命令并返回结果"""
+        try:
+            full_input = " ".join([command, *args])
+            self.running = True  # 确保底层处理逻辑生效
+            self.process_command(full_input)
+            return "\n".join(self.get_output())
+        except Exception as e:
+            logger.error(f"Command handling error: {e}")
+            return "命令处理出错"
     
     def run(self):
         """运行游戏主循环"""

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ Flask>=2.0.0
 # 核心依赖
 requests>=2.31.0  # 用于调用LLM API
 psutil>=5.9.0     # 用于系统监控和性能分析
+jsonschema>=4.0.0 # 用于配置数据验证
 
 # Python版本要求
 # Python >= 3.8

--- a/run_web_ui_v3.py
+++ b/run_web_ui_v3.py
@@ -1,0 +1,92 @@
+import threading
+import webbrowser
+from flask import Flask, render_template, request, jsonify
+from main_v3_data_driven import DataDrivenGameCore
+
+app = Flask(__name__, static_folder='static', template_folder='templates')
+
+# 创建数据驱动版本的游戏核心
+game = DataDrivenGameCore()
+# 启动新游戏
+game.start_new_game()
+
+# 日志列表
+logs = []
+# 前端刷新标记
+state_changed = True
+
+
+def flush_output():
+    """刷新并收集游戏输出"""
+    global state_changed
+    changed = False
+    for line in game.get_output():
+        logs.append(line)
+        changed = True
+    if changed:
+        state_changed = True
+
+
+@app.route('/')
+def index():
+    """主页面"""
+    flush_output()
+    state = game.game_state.to_dict()
+    player = game.game_state.player
+    buffs = []
+    if player and hasattr(player, 'status_effects'):
+        buffs = player.status_effects.get_status_summary()
+    return render_template(
+        'game.html',
+        player=state.get('player'),
+        logs=logs[-200:],
+        buffs=buffs,
+        special_status=[],
+    )
+
+
+@app.route('/status')
+def status():
+    """返回当前状态"""
+    flush_output()
+    return jsonify(game.game_state.to_dict())
+
+
+@app.route('/log')
+def log():
+    """返回最新日志"""
+    flush_output()
+    return jsonify({'logs': logs[-200:]})
+
+
+@app.route('/command', methods=['POST'])
+def command():
+    """处理指令"""
+    global state_changed
+    data = request.get_json()
+    cmd = data.get('command', '')
+    if cmd:
+        game.process_command(cmd)
+        state_changed = True
+    flush_output()
+    return jsonify({'logs': logs[-200:]})
+
+
+@app.route('/need_refresh')
+def need_refresh():
+    """检查前端是否需要刷新"""
+    global state_changed
+    flush_output()
+    if state_changed:
+        state_changed = False
+        return jsonify({'refresh': True})
+    return jsonify({'refresh': False})
+
+
+def open_browser():
+    webbrowser.open('http://127.0.0.1:5000')
+
+
+if __name__ == '__main__':
+    threading.Timer(1, open_browser).start()
+    app.run()

--- a/xwe/core/chinese_dragon_art.py
+++ b/xwe/core/chinese_dragon_art.py
@@ -91,10 +91,23 @@ def get_dragon_for_scene(scene_type):
     """根据场景返回合适的龙图案"""
     scene_dragons = {
         "welcome": "welcome",
-        "battle": "battle", 
+        "battle": "battle",
         "achievement": "achievement",
         "dialogue": "simple",
         "status": "mini",
         "help": "simple"
     }
     return get_dragon_art(scene_dragons.get(scene_type, "classic"))
+
+
+def print_chinese_dragon(style: str = "classic") -> None:
+    """直接打印指定风格的龙图案"""
+    print(get_dragon_art(style))
+
+
+__all__ = [
+    "get_dragon_art",
+    "display_dragon_with_animation",
+    "get_dragon_for_scene",
+    "print_chinese_dragon",
+]

--- a/xwe/core/combat_system_v3.py
+++ b/xwe/core/combat_system_v3.py
@@ -39,6 +39,9 @@ class CombatSystemV3:
     从JSON配置加载所有战斗规则和计算公式
     """
     
+    # 提供枚举别名，便于外部访问
+    ActionType = ActionType
+
     def __init__(self):
         self.combat_data = None
         self.element_data = None
@@ -882,6 +885,17 @@ class CombatState:
             self.damage_dealt[attacker_id][target_id] = 0
         
         self.damage_dealt[attacker_id][target_id] += damage
+
+    def record_healing(self, healer_id: str, target_id: str, amount: int):
+        """记录治疗量"""
+        if healer_id not in self.healing_done:
+            self.healing_done[healer_id] = 0
+
+        self.healing_done[healer_id] += amount
+
+    def get_healing_done_by(self, participant_id: str) -> int:
+        """获取某人完成的治疗总量"""
+        return self.healing_done.get(participant_id, 0)
     
     def get_damage_dealt_by(self, participant_id: str) -> int:
         """获取某人造成的总伤害"""

--- a/xwe/core/cultivation_system.py
+++ b/xwe/core/cultivation_system.py
@@ -61,7 +61,7 @@ class CultivationSystem:
         context = {
             "base_speed": 1.0,
             "spiritual_root_quality": spiritual_root_quality,
-            "comprehension": player.attributes.get("comprehension", 50) / 100,
+            "comprehension": getattr(player.attributes, "comprehension", 50) / 100,
             "environment_bonus": self._get_environment_bonus(player),
             "technique_efficiency": self._get_technique_efficiency(player)
         }
@@ -243,7 +243,7 @@ class CultivationSystem:
             return 0.5
         
         # 功法与境界匹配度
-        if technique.get("tier", 1) >= player.realm_tier:
+        if technique.get("tier", 1) >= getattr(player, "realm_level", 1):
             return technique.get("efficiency", 1.0)
         else:
             # 低级功法修炼高境界效率降低

--- a/xwe/core/game_core_enhanced.py
+++ b/xwe/core/game_core_enhanced.py
@@ -370,6 +370,11 @@ class EnhancedGameCore(GameCore):
         logger.info("Enhanced game core shutdown complete")
 
 
+# 向后兼容的别名，旧代码可能仍使用 GameCoreEnhanced
+class GameCoreEnhanced(EnhancedGameCore):
+    pass
+
+
 def create_enhanced_game():
     """创建增强版游戏实例"""
     game = EnhancedGameCore()

--- a/xwe/core/optimizations/expression_jit.py
+++ b/xwe/core/optimizations/expression_jit.py
@@ -2,7 +2,7 @@
 
 import ast
 import types
-from typing import Dict, Any, Callable
+from typing import Dict, Any, Callable, List
 import time
 import hashlib
 

--- a/xwe/data/ai_features_config.json
+++ b/xwe/data/ai_features_config.json
@@ -1,5 +1,3 @@
-# xwe/data/ai_features_config.json
-
 {
   "ai_features": {
     "enabled": true,

--- a/xwe/data/restructured/faction_model.json
+++ b/xwe/data/restructured/faction_model.json
@@ -359,6 +359,8 @@
       "type": "cultivation_family",
       "tier": 5,
       "description": "以云系功法闻名的修真世家",
+      "influence": 15000,
+      "wealth": 5000000,
       "bloodline": {
         "name": "云龙血脉",
         "activation_rate": 0.3,


### PR DESCRIPTION
## Summary
- implement `handle_command` in `main_v3_data_driven.py`
- read player comprehension with `getattr` to support simple objects
- add a web UI launcher for the data-driven engine
- document new script in README and STARTERS guide

## Testing
- `pip install -r requirements.txt`
- `pytest tests/ -v`


------
https://chatgpt.com/codex/tasks/task_e_6844716c14c4832887b27d7c02bfce30