### PR TITLE
Integrate game time into enhanced dialogue

### DIFF
--- a/xwe/core/game_core.py
+++ b/xwe/core/game_core.py
@@ -1158,7 +1158,9 @@ class GameCore:
         }
         
         # 开始对话
-        first_node = self.npc_manager.start_dialogue(player.id, npc_id)
+        first_node = self.npc_manager.start_dialogue(
+            player.id, npc_id, game_time=self.game_state.game_time
+        )
         if first_node:
             self._display_dialogue_node(first_node, npc_found['name'])
         else:

--- a/xwe/npc/npc_manager.py
+++ b/xwe/npc/npc_manager.py
@@ -333,7 +333,7 @@ class NPCManager:
         return [npc_id for npc_id, loc in self.npc_locations.items() if loc == location]
     
     def start_dialogue(self, player_id: str, npc_id: str, player_info: Dict[str, Any] = None,
-                      use_enhanced: bool = True) -> Optional[DialogueNode]:
+                      use_enhanced: bool = True, game_time: int = 0) -> Optional[DialogueNode]:
         """
         开始与NPC对话
         
@@ -365,7 +365,7 @@ class NPCManager:
         if use_enhanced:
             # 使用增强版对话系统
             node, _ = self.enhanced_dialogue.start_dialogue(
-                player_id, npc_id, npc_info, player_info
+                player_id, npc_id, npc_info, player_info, game_time
             )
             return node
         else:


### PR DESCRIPTION
## Summary
- connect enhanced dialogue to actual game time
- record timestamps in NPC memories
- propagate `game_time` through NPC manager and game core

## Testing
- `pytest tests/ -v`

------
https://chatgpt.com/codex/tasks/task_e_6846453449c0832885dc3888df155fd3