### PR TITLE
Add JSON parsing unit tests

### DIFF
--- a/tests/unit/test_parse_deepseek_json.py
+++ b/tests/unit/test_parse_deepseek_json.py
@@ -1,0 +1,26 @@
+import pytest
+from xwe.core.nlp.nlp_processor import NLPProcessor, NLPConfig
+
+
+@pytest.fixture
+def nlp():
+    return NLPProcessor(config=NLPConfig(enable_llm=False))
+
+
+def test_parse_plain_json(nlp):
+    raw = '{"command": "ATTACK", "confidence": 0.8}'
+    parsed = nlp._parse_deepseek_json(raw)
+    assert parsed == {"command": "ATTACK", "confidence": 0.8}
+
+
+def test_parse_markdown_json(nlp):
+    raw = "```json\n{\"command\": \"STATUS\"}\n```"
+    parsed = nlp._parse_deepseek_json(raw)
+    assert parsed == {"command": "STATUS"}
+
+
+def test_parse_json_in_text(nlp):
+    raw = "response: {\"command\": \"FLEE\"}" \
+          " some trailing text"
+    parsed = nlp._parse_deepseek_json(raw)
+    assert parsed == {"command": "FLEE"}


### PR DESCRIPTION
## Summary
- add `test_parse_deepseek_json` to cover DeepSeek JSON extraction logic

## Testing
- `pytest tests/unit/test_parse_deepseek_json.py -v`
- `pytest tests/ -v`

------
https://chatgpt.com/codex/tasks/task_e_68464a6e2e1c8328943b2cd4e8858398