### PR TITLE
Fix narrative import and support dict players in HTML logger

### DIFF
--- a/xwe/features/__init__.py
+++ b/xwe/features/__init__.py
@@ -23,6 +23,7 @@ from .narrative_system import (
     AchievementSystem,
     StoryBranchManager,
     NarrativeEventSystem,
+    NarrativeSystem,
     narrative_system,
     create_immersive_opening,
     check_and_display_achievements
@@ -121,6 +122,7 @@ __all__ = [
     
     # 叙事系统
     "narrative_system",
+    "NarrativeSystem",
     "create_immersive_opening",
     "check_and_display_achievements",
     

--- a/xwe/features/html_output.py
+++ b/xwe/features/html_output.py
@@ -12,15 +12,26 @@ class HtmlGameLogger:
         """更新角色状态"""
         if not player:
             return
-        attrs = player.attributes
-        self.status = {
-            "名字": player.name,
-            "境界": f"{attrs.realm_name} {attrs.cultivation_level}层",
-            "气血": f"{int(attrs.current_health)}/{int(attrs.max_health)}",
-            "灵力": f"{int(attrs.current_mana)}/{int(attrs.max_mana)}",
-            "攻击": int(attrs.get('attack_power')),
-            "防御": int(attrs.get('defense')),
-        }
+        # 支持传入字典或拥有 attributes 属性的对象
+        if isinstance(player, dict):
+            self.status = {
+                "名字": player.get("name", ""),
+                "境界": f"{player.get('realm', '')}第{player.get('level', 1)}层",
+                "气血": f"{player.get('health', 0)}/{player.get('max_health', 0)}",
+                "法力": f"{player.get('mana', 0)}/{player.get('max_mana', 0)}",
+                "攻击": player.get('attack', 0),
+                "防御": player.get('defense', 0),
+            }
+        else:
+            attrs = player.attributes
+            self.status = {
+                "名字": player.name,
+                "境界": f"{attrs.realm_name} {attrs.cultivation_level}层",
+                "气血": f"{int(attrs.current_health)}/{int(attrs.max_health)}",
+                "灵力": f"{int(attrs.current_mana)}/{int(attrs.max_mana)}",
+                "攻击": int(attrs.get('attack_power')),
+                "防御": int(attrs.get('defense')),
+            }
         self._write_html()
 
     def add_log(self, text: str, category: str = "system", is_continuation: bool = False):

--- a/xwe/features/narrative_system.py
+++ b/xwe/features/narrative_system.py
@@ -704,5 +704,10 @@ def check_and_display_achievements(player_stats: Dict[str, Any]) -> List[str]:
                 msg += f"\n   • {reward_type}: {reward_value}"
         
         messages.append(msg)
-    
+
     return messages
+
+# 兼容旧代码的别名
+class NarrativeSystem(NarrativeEventSystem):
+    """`NarrativeEventSystem` 的别名，保持向后兼容"""
+    pass


### PR DESCRIPTION
## Summary
- add `NarrativeSystem` alias to keep backwards compatibility
- export `NarrativeSystem` through `xwe.features`
- allow `HtmlGameLogger.update_status` to accept player dictionaries

## Testing
- `pytest tests/unit/test_nlp.py::test_nlp_fuzzy_matching -q`
- `pytest tests/test_features.py::test_narrative_system -q`


------
https://chatgpt.com/codex/tasks/task_e_6846911975108328aebccc31052b47ed