### PR TITLE
Fix missing AI and technical ops classes

### DIFF
--- a/run_web_ui_optimized.py
+++ b/run_web_ui_optimized.py
@@ -37,7 +37,8 @@ def get_game_instance(session_id):
         game = EnhancedGameCore()
         
         # 初始化各系统
-        game.cultivation_system = CultivationSystem(game)
+        # CultivationSystem 构造函数不接受游戏实例参数
+        game.cultivation_system = CultivationSystem()
         game.narrative_system = NarrativeSystem()
         game.ai_personalization = AIPersonalization()
         game.community_system = CommunitySystem()

--- a/xwe/features/__init__.py
+++ b/xwe/features/__init__.py
@@ -23,6 +23,7 @@ from .narrative_system import (
     AchievementSystem,
     StoryBranchManager,
     NarrativeEventSystem,
+    NarrativeSystem,
     narrative_system,
     create_immersive_opening,
     check_and_display_achievements
@@ -50,6 +51,7 @@ from .ai_personalization import (
     AdaptiveGuideSystem,
     DynamicNPCBehavior,
     PersonalizationEngine,
+    AIPersonalization,
     personalization_engine,
     enhance_with_ai_features
 )
@@ -79,6 +81,7 @@ from .technical_ops import (
     PerformanceMonitor,
     AutoBackupManager,
     TechnicalOpsSystem,
+    TechnicalOps,
     tech_ops_system,
     integrate_technical_features
 )
@@ -121,14 +124,16 @@ __all__ = [
     
     # 叙事系统
     "narrative_system",
+    "NarrativeSystem",
     "create_immersive_opening",
     "check_and_display_achievements",
     
     # 内容生态
     "content_ecosystem",
-    
+
     # AI个性化
     "personalization_engine",
+    "AIPersonalization",
     "enhance_with_ai_features",
     
     # 社区系统
@@ -139,6 +144,7 @@ __all__ = [
     
     # 技术运营
     "tech_ops_system",
+    "TechnicalOps",
     "integrate_technical_features",
     
     # 视觉增强

--- a/xwe/features/ai_personalization.py
+++ b/xwe/features/ai_personalization.py
@@ -626,6 +626,11 @@ class PersonalizationEngine:
 # 全局实例
 personalization_engine = PersonalizationEngine()
 
+# 向后兼容的别名
+class AIPersonalization(PersonalizationEngine):
+    """`PersonalizationEngine` 的别名, 兼容旧代码"""
+    pass
+
 def enhance_with_ai_features(game_core):
     """为游戏核心添加AI功能"""
     original_process_command = game_core.process_command
@@ -669,3 +674,4 @@ def enhance_with_ai_features(game_core):
     game_core.get_ai_recommendation = lambda: personalization_engine.get_personalized_content("player_1")
     
     logger.info("AI个性化功能已启用")
+

--- a/xwe/features/html_output.py
+++ b/xwe/features/html_output.py
@@ -12,15 +12,26 @@ class HtmlGameLogger:
         """更新角色状态"""
         if not player:
             return
-        attrs = player.attributes
-        self.status = {
-            "名字": player.name,
-            "境界": f"{attrs.realm_name} {attrs.cultivation_level}层",
-            "气血": f"{int(attrs.current_health)}/{int(attrs.max_health)}",
-            "灵力": f"{int(attrs.current_mana)}/{int(attrs.max_mana)}",
-            "攻击": int(attrs.get('attack_power')),
-            "防御": int(attrs.get('defense')),
-        }
+        # 支持传入字典或拥有 attributes 属性的对象
+        if isinstance(player, dict):
+            self.status = {
+                "名字": player.get("name", ""),
+                "境界": f"{player.get('realm', '')}第{player.get('level', 1)}层",
+                "气血": f"{player.get('health', 0)}/{player.get('max_health', 0)}",
+                "法力": f"{player.get('mana', 0)}/{player.get('max_mana', 0)}",
+                "攻击": player.get('attack', 0),
+                "防御": player.get('defense', 0),
+            }
+        else:
+            attrs = player.attributes
+            self.status = {
+                "名字": player.name,
+                "境界": f"{attrs.realm_name} {attrs.cultivation_level}层",
+                "气血": f"{int(attrs.current_health)}/{int(attrs.max_health)}",
+                "灵力": f"{int(attrs.current_mana)}/{int(attrs.max_mana)}",
+                "攻击": int(attrs.get('attack_power')),
+                "防御": int(attrs.get('defense')),
+            }
         self._write_html()
 
     def add_log(self, text: str, category: str = "system", is_continuation: bool = False):

--- a/xwe/features/narrative_system.py
+++ b/xwe/features/narrative_system.py
@@ -704,5 +704,10 @@ def check_and_display_achievements(player_stats: Dict[str, Any]) -> List[str]:
                 msg += f"\n   • {reward_type}: {reward_value}"
         
         messages.append(msg)
-    
+
     return messages
+
+# 兼容旧代码的别名
+class NarrativeSystem(NarrativeEventSystem):
+    """`NarrativeEventSystem` 的别名，保持向后兼容"""
+    pass

--- a/xwe/features/technical_ops.py
+++ b/xwe/features/technical_ops.py
@@ -923,3 +923,9 @@ def integrate_technical_features(game_core):
     game_core.get_system_status = tech_ops_system.get_system_status
     
     logger.info("技术功能已集成")
+
+# 向后兼容的别名
+class TechnicalOps(TechnicalOpsSystem):
+    """`TechnicalOpsSystem` 的别名, 兼容旧代码"""
+    pass
+


### PR DESCRIPTION
## Summary
- add `AIPersonalization` alias for old imports
- add `TechnicalOps` alias for old imports
- re-export these classes in feature package
- adjust cultivation system initialization in `run_web_ui_optimized`

## Testing
- `pytest tests/ -v` *(failed: Codex couldn't run certain commands due to environment limitations)*

------
https://chatgpt.com/codex/tasks/task_e_6846911975108328aebccc31052b47ed