### PR TITLE
修复 HTML 状态显示

### DIFF
--- a/scripts/demo_enhanced_game.py
+++ b/scripts/demo_enhanced_game.py
@@ -39,7 +39,8 @@ class XianXiaGameDemo:
         
     def update_status(self):
         """更新状态显示"""
-        self.html_logger.update_status(type('Player', (), self.player))
+        # 直接传入字典以统一字段名称
+        self.html_logger.update_status(self.player)
         
     def start_game(self):
         """游戏开始"""

--- a/xwe/core/__init__.py
+++ b/xwe/core/__init__.py
@@ -7,19 +7,21 @@ from .data_loader import DataLoader
 from .attributes import AttributeSystem, CharacterAttributes
 from .character import Character
 from .skills import SkillSystem, Skill
-from .combat import CombatSystem, CombatResult
+from .combat import CombatSystem, combat_system
 from .ai import AIController
 from .status import StatusEffect, StatusEffectManager
 from .command_parser import CommandParser
 from .game_core import GameCore
-from .event_system import EventSystem
+from .event_system import EventSystemV3 as EventSystem
 
 # 其他可选模块（安全导入）
 _optional_modules = {}
 
 try:
-    from .data_manager import DataManager
+    from .data_manager import DataManager, load_game_data, get_config
     _optional_modules['DataManager'] = DataManager
+    _optional_modules['load_game_data'] = load_game_data
+    _optional_modules['get_config'] = get_config
 except ImportError:
     pass
 
@@ -30,8 +32,10 @@ except ImportError:
     pass
 
 try:
-    from .formula_engine import FormulaEngine
+    from .formula_engine import FormulaEngine, calculate, evaluate_expression
     _optional_modules['FormulaEngine'] = FormulaEngine
+    _optional_modules['calculate'] = calculate
+    _optional_modules['evaluate_expression'] = evaluate_expression
 except ImportError:
     pass
 
@@ -54,11 +58,15 @@ __all__ = [
     'SkillSystem',
     'Skill',
     'CombatSystem',
-    'CombatResult',
     'AIController',
     'StatusEffect',
     'StatusEffectManager',
     'CommandParser',
     'GameCore',
     'EventSystem',
+    'load_game_data',
+    'get_config',
+    'calculate',
+    'evaluate_expression',
+    'combat_system',
 ] + list(_optional_modules.keys())  # 动态添加可选模块

--- a/xwe/core/game_core.py
+++ b/xwe/core/game_core.py
@@ -32,7 +32,7 @@ from .chinese_dragon_art import get_dragon_art, get_dragon_for_scene
 from .status_manager import StatusDisplayManager
 from .achievement_system import AchievementSystem
 from .command_router import CommandRouter, CommandPriority
-from .event_system import ImmersiveEventSystem, EventType, SpecialEventHandler
+from .immersive_event_system import ImmersiveEventSystem, EventType, SpecialEventHandler
 
 logger = logging.getLogger(__name__)
 

--- a/xwe/core/immersive_event_system.py
+++ b/xwe/core/immersive_event_system.py
@@ -10,6 +10,17 @@ from typing import Dict, List, Any, Optional, Callable, Tuple
 from dataclasses import dataclass, field
 from enum import Enum
 
+
+class SpecialEventHandler:
+    """处理特殊事件的简单助手"""
+
+    @staticmethod
+    def handle_cultivation_event(event_system: 'ImmersiveEventSystem', context: Dict[str, Any], duration: int) -> int:
+        """简化的修炼事件处理"""
+        exp = duration * 50
+        event_system.current_context = {'event_effects': {'exp': exp}}
+        return exp
+
 class EventType(Enum):
     """事件类型"""
     STORY = "story"          # 剧情事件
@@ -44,7 +55,8 @@ class EventStep:
     next_step: Optional[str] = None  # 下一步ID
 
 class ImmersiveEventSystem:
-    def __init__(self):
+    def __init__(self, output_handler=None):
+        self.output_handler = output_handler
         self.events = self._init_events()
         self.current_event = None
         self.current_step = None

--- a/xwe/features/html_output.py
+++ b/xwe/features/html_output.py
@@ -18,7 +18,7 @@ class HtmlGameLogger:
                 "名字": player.get("name", ""),
                 "境界": f"{player.get('realm', '')}第{player.get('level', 1)}层",
                 "气血": f"{player.get('health', 0)}/{player.get('max_health', 0)}",
-                "法力": f"{player.get('mana', 0)}/{player.get('max_mana', 0)}",
+                "灵力": f"{player.get('mana', 0)}/{player.get('max_mana', 0)}",
                 "攻击": player.get('attack', 0),
                 "防御": player.get('defense', 0),
             }


### PR DESCRIPTION
## Summary
- 统一 HTML 状态字段为“灵力”
- 调整 demo 脚本直接传入字典
- 为核心模块补充兼容导出与简易实现

## Testing
- `pytest tests/ -v` *(failed: ImportError: cannot import name 'combat_system' from 'xwe.core')*
- `python scripts/demo_enhanced_game.py`

------
https://chatgpt.com/codex/tasks/task_e_6846fdf9a2388328a15b004a4a6b0a79