### PR TITLE
Add env example template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+DEEPSEEK_API_KEY=your_deepseek_api_key
+OPENAI_API_KEY=your_openai_api_key
+DEFAULT_LLM_PROVIDER=mock

--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ cd xianxia_world_engine
 pip install -r requirements.txt  # 包含 jsonschema 等核心库
 
 # 3. 配置API（可选，用于AI功能）
-export DEEPSEEK_API_KEY="your-api-key"
+cp .env.example .env  # 复制示例配置文件
+# 然后编辑 `.env` 填入相应的 API 密钥
 ```
 
 ## 🎮 游戏特性


### PR DESCRIPTION
## Summary
- provide `.env.example` with placeholder API keys
- guide users to copy the example file in installation steps

## Testing
- `pytest tests/test_features.py::test_player_experience -v`
- `pytest tests/ -v` *(fails: CombatSystemV3.create_combat missing positional argument)*

------
https://chatgpt.com/codex/tasks/task_e_6847d196667883289947a9184521f3a8