### PR TITLE
Update testing docs for LLM mock

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,8 +208,9 @@ python scripts/init_features.py
 
 ### 运行测试
 ```bash
-# 运行所有测试
-python run_all_tests.py
+# 运行所有测试（默认使用 mock 模式）
+export LLM_PROVIDER=mock
+python tests/run_all_tests.py
 
 # 测试特定功能
 python test_features.py
@@ -218,6 +219,9 @@ python test_optimizations.py
 # 运行单元测试
 python -m pytest tests/unit/
 ```
+
+如需使用真实 LLM 进行测试，可在 `.env` 中填入 API 密钥，并将
+`LLM_PROVIDER` 设置为实际提供商。
 
 ## 📚 API文档
 

--- a/tests/run_all_tests.py
+++ b/tests/run_all_tests.py
@@ -1,7 +1,16 @@
 #!/usr/bin/env python3
 """
 XianXia World Engine - 自动化测试脚本
-运行所有单元测试和集成测试，并生成报告
+运行所有单元测试和集成测试，并生成报告。
+
+在运行此脚本前，请设置環境变量 `LLM_PROVIDER=mock`，例如：
+
+```bash
+export LLM_PROVIDER=mock
+python tests/run_all_tests.py
+```
+
+如需真实 LLM 测试，可在 `.env` 中配置 API 密钥。
 """
 
 import sys
@@ -9,6 +18,11 @@ import os
 import subprocess
 import json
 import time
+
+# 默认使用 mock 提供商，除非外部已设置
+if not os.getenv("LLM_PROVIDER"):
+    os.environ["LLM_PROVIDER"] = "mock"
+    print("⚠️ LLM_PROVIDER 未设置，已使用 'mock' 进行测试")
 from pathlib import Path
 from datetime import datetime
 from xwe.utils.requests_helper import ensure_requests


### PR DESCRIPTION
## Summary
- highlight `LLM_PROVIDER=mock` when running test harness
- mention real LLM testing in docs
- default to mock provider in `tests/run_all_tests.py`

## Testing
- `pip install -r requirements.txt`
- `pytest tests/ -v` *(fails: test run interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_6847d199ee44832881f81b98fe72368c