### PR TITLE
Fix service exports and web UI import

### DIFF
--- a/run_web_ui.py
+++ b/run_web_ui.py
@@ -1,10 +1,9 @@
 import threading
 import webbrowser
-from flask import Flask
+from flask import Flask, render_template, request, jsonify
 
 # 导入服务层
 from xwe.services import ServiceContainer, register_services
-, render_template, request, jsonify
 from xwe.core.game_core import GameCore
 
 app = Flask(__name__, static_folder='static', template_folder='templates')

--- a/xwe/services/__init__.py
+++ b/xwe/services/__init__.py
@@ -327,3 +327,36 @@ def register_services(container: ServiceContainer) -> None:
     container.register(ILogService, LogService, ServiceLifetime.SINGLETON)
     
     logger.info("All services registered")
+
+
+# 对外暴露的接口类型，方便统一导入
+from .game_service import IGameService
+from .player_service import IPlayerService
+from .combat_service import ICombatService
+from .save_service import ISaveService
+from .world_service import IWorldService
+from .cultivation_service import ICultivationService
+from .command_engine import ICommandEngine
+from .event_dispatcher import IEventDispatcher
+from .log_service import ILogService
+
+__all__ = [
+    "ServiceLifetime",
+    "IService",
+    "ServiceBase",
+    "ServiceDescriptor",
+    "ServiceNotFoundError",
+    "ServiceContainer",
+    "ServiceScope",
+    "get_service_container",
+    "register_services",
+    "IGameService",
+    "IPlayerService",
+    "ICombatService",
+    "ISaveService",
+    "IWorldService",
+    "ICultivationService",
+    "ICommandEngine",
+    "IEventDispatcher",
+    "ILogService",
+]


### PR DESCRIPTION
## Summary
- expose service interface names in `xwe.services`
- fix Flask import in `run_web_ui.py`

## Testing
- `python tests/test_services.py`
- `pytest tests/ -v` *(fails: runtime too long)*

------
https://chatgpt.com/codex/tasks/task_e_684995e0ad94832882d8052b4fc9a325