### PR TITLE
Fix safe wrapper simple parse

### DIFF
--- a/xwe/core/nlp/safe_wrapper.py
+++ b/xwe/core/nlp/safe_wrapper.py
@@ -34,15 +34,15 @@ class SafeNLPWrapper:
         text_lower = text.lower()
         
         # 基础规则匹配
-        if Any(word in text_lower for word in ['攻击', '打', '杀']):
+        if any(word in text_lower for word in ['攻击', '打', '杀']):
             return {"action": "attack", "target": "敌人", "confidence": 0.5}
-        elif Any(word in text_lower for word in ['修炼', '打坐', '冥想']):
+        elif any(word in text_lower for word in ['修炼', '打坐', '冥想']):
             return {"action": "cultivate", "confidence": 0.6}
-        elif Any(word in text_lower for word in ['状态', '属性', '面板']):
+        elif any(word in text_lower for word in ['状态', '属性', '面板']):
             return {"action": "status", "confidence": 0.7}
-        elif Any(word in text_lower for word in ['逃', '跑', '撤退']):
+        elif any(word in text_lower for word in ['逃', '跑', '撤退']):
             return {"action": "flee", "confidence": 0.6}
-        elif Any(word in text_lower for word in ['地图', '位置', '哪里']):
+        elif any(word in text_lower for word in ['地图', '位置', '哪里']):
             return {"action": "map", "confidence": 0.6}
         else:
             return {"action": "unknown", "detail": f"无法理解: {text}", "confidence": 0.0}


### PR DESCRIPTION
## Summary
- use built-in `any` in `_simple_parse` of `SafeNLPWrapper`

## Testing
- `pip install -r requirements.txt`
- `pytest tests/ -v` *(fails: SyntaxError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_684a8b2cdbb883288b04a214302c36a5