### PR TITLE
Fix connected area ids string

### DIFF
--- a/xwe/world/world_map.py
+++ b/xwe/world/world_map.py
@@ -293,7 +293,7 @@ class WorldMap:
                 'available_actions': area.available_actions,
                 'connected_areas': [
                     {
-                        'id': cid,
+                        'id': str(cid),
                         'name': self.areas[cid].name if cid in self.areas else "未知",
                         'discovered': self.areas[cid].is_discovered if cid in self.areas else False
                     }


### PR DESCRIPTION
## Summary
- ensure string id keys when returning connected areas

## Testing
- `pip install -r requirements.txt`
- `pytest tests/ -v` *(fails: SyntaxError in tests/unit/test_api.py)*

------
https://chatgpt.com/codex/tasks/task_e_684a8b2daf748328bcb69a128ce8c248