### PR TITLE
Add typing to error handling attributes

### DIFF
--- a/xwe/features/technical_ops.py
+++ b/xwe/features/technical_ops.py
@@ -395,12 +395,12 @@ class ErrorHandler:
         self.crash_dir.mkdir(exist_ok=True)
         
         # 错误统计
-        self.error_counts = {}
-        self.last_errors = []
+        self.error_counts: Dict[str, int] = {}
+        self.last_errors: List[ErrorLog] = []
         self.max_recent_errors = 100
-        
+
         # 错误处理回调
-        self.error_callbacks = []
+        self.error_callbacks: List[Callable[[ErrorLog], Any]] = []
     
     def handle_error(self, 
                     error: Exception,
@@ -513,7 +513,7 @@ class PerformanceMonitor:
     """性能监控器"""
     
     def __init__(self):
-        self.metrics = {
+        self.metrics: Dict[str, List[float]] = {
             "fps": [],
             "frame_time": [],
             "memory_usage": [],
@@ -525,14 +525,14 @@ class PerformanceMonitor:
         self.sample_interval = 1.0  # 采样间隔（秒）
         
         # 性能阈值
-        self.thresholds = {
+        self.thresholds: Dict[str, float] = {
             "fps_min": 30,
             "memory_max_mb": 500,
             "cpu_max_percent": 80
         }
         
         # 性能报警回调
-        self.alert_callbacks = []
+        self.alert_callbacks: List[Callable[[Dict[str, Any]], Any]] = []
     
     def start_monitoring(self):
         """开始监控"""

--- a/xwe/services/combat_service.py
+++ b/xwe/services/combat_service.py
@@ -52,7 +52,7 @@ class CombatService(ServiceBase[ICombatService], ICombatService):
         super().__init__(container)
         self._in_combat = False
         self._current_enemy = None
-        self._combat_log = []
+        self._combat_log: List[str] = []
         
     def start_combat(self, enemy_data: Dict[str, Any]) -> bool:
         """开始战斗"""

--- a/xwe/services/game_service.py
+++ b/xwe/services/game_service.py
@@ -97,8 +97,8 @@ class GameService(ServiceBase[IGameService], IGameService):
         self._game_time = 0
         self._in_combat = False
         self._current_location = "天南镇"
-        self._logs = []
-        self._events = []
+        self._logs: List[Dict[str, Any]] = []
+        self._events: List[Dict[str, Any]] = []
         self._event_bus = None
         self._player_service = None
         self._world_service = None

--- a/xwe/services/world_service.py
+++ b/xwe/services/world_service.py
@@ -54,9 +54,9 @@ class WorldService(ServiceBase[IWorldService], IWorldService):
     
     def __init__(self, container: ServiceContainer):
         super().__init__(container)
-        self._locations = {}
-        self._connections = {}
-        self._discovered_locations = set()
+        self._locations: Dict[str, Dict[str, Any]] = {}
+        self._connections: Dict[str, List[str]] = {}
+        self._discovered_locations: set[str] = set()
         
     def _do_initialize(self) -> None:
         """初始化服务"""


### PR DESCRIPTION
## Summary
- type annotate `error_counts` and related lists
- update service classes to use typed collections

## Testing
- `pip install -r requirements.txt`
- `pytest tests/ -v` *(fails: ModuleNotFoundError: No module named 'run_web_ui')*

------
https://chatgpt.com/codex/tasks/task_e_684a8b2f209c8328bf227817cdf76084