### PR TITLE
Fix dataclass mutable defaults

### DIFF
--- a/xwe/core/command_parser.py
+++ b/xwe/core/command_parser.py
@@ -7,7 +7,7 @@
 
 import re
 from typing import Dict, Any, List, Optional, Tuple, Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 import logging
 
@@ -62,13 +62,10 @@ class ParsedCommand:
     """解析后的命令"""
     command_type: CommandType
     target: Optional[str] = None
-    parameters: Dict[str, Any] = None
+    parameters: Dict[str, Any] = field(default_factory=dict)
     raw_text: str = ""
     confidence: float = 1.0
     
-    def __post_init__(self):
-        if self.parameters is None:
-            self.parameters = {}
 
 
 class CommandPattern:

--- a/xwe/core/command_router.py
+++ b/xwe/core/command_router.py
@@ -6,7 +6,7 @@
 
 import re
 from typing import Dict, Callable, Any, Optional, Tuple, List
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import Enum
 
 
@@ -26,7 +26,7 @@ class CommandDefinition:
     priority: CommandPriority  # 优先级
     description: str        # 命令描述
     context_required: Optional[str] = None  # 所需上下文
-    aliases: List[str] = None  # 别名列表
+    aliases: List[str] = field(default_factory=list)  # 别名列表
 
 class CommandRouter:
     def __init__(self):

--- a/xwe/core/confirmation_manager.py
+++ b/xwe/core/confirmation_manager.py
@@ -3,7 +3,7 @@
 """
 
 from typing import Dict, Callable, Any, Optional
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import uuid
 
 
@@ -14,7 +14,7 @@ class PendingConfirmation:
     action: str
     description: str
     callback: Callable
-    data: Dict[str, Any]
+    data: Dict[str, Any] = field(default_factory=dict)
 
 
 class ConfirmationManager:

--- a/xwe/features/auction_system.py
+++ b/xwe/features/auction_system.py
@@ -15,7 +15,7 @@ import time
 from typing import Dict, List, Optional, Tuple, Any
 from pathlib import Path
 from enum import Enum
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from xwe.core.data_loader import DataLoader
 try:
@@ -57,11 +57,7 @@ class AuctionItem:
     max_price: int
     current_bid: int = 0
     current_bidder: Optional[str] = None
-    bid_history: List[Tuple[str, int]] = None
-    
-    def __post_init__(self):
-        if self.bid_history is None:
-            self.bid_history = []
+    bid_history: List[Tuple[str, int]] = field(default_factory=list)
 
 
 @dataclass
@@ -75,11 +71,7 @@ class Bidder:
     personality: Dict[str, float]
     grudge_target: Optional[str] = None
     bid_count: int = 0
-    items_won: List[str] = None
-    
-    def __post_init__(self):
-        if self.items_won is None:
-            self.items_won = []
+    items_won: List[str] = field(default_factory=list)
 
 
 class AuctionSystem:

--- a/xwe/services/command_engine.py
+++ b/xwe/services/command_engine.py
@@ -5,7 +5,7 @@
 
 from abc import ABC, abstractmethod
 from typing import Dict, Any, Optional, List, Callable, Tuple
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import re
 import logging
 
@@ -22,11 +22,7 @@ class CommandContext:
     player_id: Optional[str] = None
     location: Optional[str] = None
     in_combat: bool = False
-    metadata: Dict[str, Any] = None
-    
-    def __post_init__(self):
-        if self.metadata is None:
-            self.metadata = {}
+    metadata: Dict[str, Any] = field(default_factory=dict)
 
 
 @dataclass 
@@ -35,16 +31,10 @@ class CommandResult:
     success: bool
     output: str
     state_changed: bool = False
-    events: List[Dict[str, Any]] = None
-    suggestions: List[str] = None
+    events: List[Dict[str, Any]] = field(default_factory=list)
+    suggestions: List[str] = field(default_factory=list)
     require_confirmation: bool = False
-    confirmation_data: Dict[str, Any] = None
-    
-    def __post_init__(self):
-        if self.events is None:
-            self.events = []
-        if self.suggestions is None:
-            self.suggestions = []
+    confirmation_data: Dict[str, Any] = field(default_factory=dict)
 
 
 class ICommandHandler(ABC):

--- a/xwe/services/game_service.py
+++ b/xwe/services/game_service.py
@@ -5,7 +5,7 @@
 
 from abc import ABC, abstractmethod
 from typing import Optional, Dict, Any, List
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import time
 
 from . import ServiceBase, ServiceContainer
@@ -18,14 +18,9 @@ class CommandResult:
     success: bool
     output: str
     state_changed: bool = False
-    events: List[Dict[str, Any]] = None
-    suggestions: List[str] = None
+    events: List[Dict[str, Any]] = field(default_factory=list)
+    suggestions: List[str] = field(default_factory=list)
     
-    def __post_init__(self):
-        if self.events is None:
-            self.events = []
-        if self.suggestions is None:
-            self.suggestions = []
 
 
 @dataclass
@@ -36,11 +31,7 @@ class GameState:
     current_location: str
     game_time: float
     player_id: Optional[str] = None
-    active_events: List[str] = None
-    
-    def __post_init__(self):
-        if self.active_events is None:
-            self.active_events = []
+    active_events: List[str] = field(default_factory=list)
 
 
 class IGameService(ABC):

--- a/xwe/services/interfaces/game_service.py
+++ b/xwe/services/interfaces/game_service.py
@@ -5,7 +5,7 @@
 
 from abc import ABC, abstractmethod
 from typing import Optional, Dict, Any, List
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 
 @dataclass
@@ -16,12 +16,8 @@ class GameState:
     current_location: str
     game_time: float
     player_id: Optional[str] = None
-    active_events: List[str] = None
+    active_events: List[str] = field(default_factory=list)
     paused: bool = False
-    
-    def __post_init__(self):
-        if self.active_events is None:
-            self.active_events = []
 
 
 @dataclass
@@ -30,16 +26,10 @@ class CommandResult:
     success: bool
     output: str
     state_changed: bool = False
-    events: List[Dict[str, Any]] = None
-    suggestions: List[str] = None
+    events: List[Dict[str, Any]] = field(default_factory=list)
+    suggestions: List[str] = field(default_factory=list)
     require_confirmation: bool = False
-    confirmation_data: Dict[str, Any] = None
-    
-    def __post_init__(self):
-        if self.events is None:
-            self.events = []
-        if self.suggestions is None:
-            self.suggestions = []
+    confirmation_data: Dict[str, Any] = field(default_factory=dict)
 
 
 class IGameService(ABC):

--- a/xwe/world/location_manager.py
+++ b/xwe/world/location_manager.py
@@ -7,7 +7,7 @@
 
 import logging
 from typing import Dict, List, Optional, Tuple, Set, Any
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import random
 
 from .world_map import WorldMap, Area, AreaType
@@ -24,11 +24,7 @@ class TravelInfo:
     distance: int
     travel_time: int  # 回合数
     stamina_cost: int
-    encounters: List[str] = None
-    
-    def __post_init__(self):
-        if self.encounters is None:
-            self.encounters = []
+    encounters: List[str] = field(default_factory=list)
 
 
 class LocationManager:


### PR DESCRIPTION
## Summary
- import `field` where needed for dataclasses
- use `field(default_factory=...)` for list and dict attributes in core and service modules
- simplify dataclasses that previously used `__post_init__` for defaults

## Testing
- `pip install -r requirements.txt`
- `pytest tests/ -v` *(fails: SyntaxError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_684a8b27e614832895b87053428b64ae