### PR TITLE
Fix test_api syntax error

### DIFF
--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -210,9 +210,7 @@ def test_error_handling():
     tester.test_endpoint('GET', '/invalid/endpoint', expected_status=404)
     
     # 测试无效的请求数据
-    tester.test_endpoint('POST', '/game/command', 
-                        data: Dict[str, Any] = {},  # 缺少required字段
-                        expected_status=400)
+    tester.test_endpoint('POST', '/game/command', data={}, expected_status=400)
     
     # 测试无效的命令
     tester.test_endpoint('POST', '/game/command',


### PR DESCRIPTION
## Summary
- fix invalid syntax in test_api when testing bad request

## Testing
- `pytest tests/unit/test_api.py -v`

------
https://chatgpt.com/codex/tasks/task_e_684a8ef9e7ec83289d3341b4d6431d00