### PR TITLE
Fix world map ID types

### DIFF
--- a/tests/unit/test_world_map_info.py
+++ b/tests/unit/test_world_map_info.py
@@ -1,0 +1,69 @@
+import sys
+from pathlib import Path
+
+# Add project root to path
+project_root = Path(__file__).parent
+sys.path.insert(0, str(project_root))
+
+from xwe.world import WorldMap, LocationManager
+from xwe.world.world_map import Area, Region, AreaType
+
+
+def test_get_area_info_keys_and_string_id():
+    wm = WorldMap()
+    area = Area.from_dict({
+        "id": 1,
+        "name": "数字区域",
+        "type": "city",
+        "description": "测试",
+        "connected_areas": [],
+        "parent_region": 0
+    })
+    wm.add_area(area)
+    info = wm.get_area_info("1")
+
+    assert all(isinstance(k, str) for k in info.keys())
+    assert info["id"] == "1"
+
+
+def test_get_regions_info_string_id():
+    wm = WorldMap()
+    region = Region.from_dict({
+        "id": 2,
+        "name": "数字州",
+        "description": "desc",
+        "sub_areas": []
+    })
+    wm.add_region(region)
+    info = wm.get_regions_info()[0]
+
+    assert all(isinstance(k, str) for k in info.keys())
+    assert info["id"] == "2"
+
+
+def test_get_nearby_areas_ids_are_strings():
+    wm = WorldMap()
+    area1 = Area.from_dict({
+        "id": 1,
+        "name": "A",
+        "type": "city",
+        "description": "",
+        "connected_areas": [2]
+    })
+    area2 = Area.from_dict({
+        "id": 2,
+        "name": "B",
+        "type": "city",
+        "description": "",
+        "connected_areas": [1]
+    })
+    wm.add_area(area1)
+    wm.add_area(area2)
+
+    lm = LocationManager(wm)
+    lm.set_location("p", "1")
+    nearby = lm.get_nearby_areas("p")
+    assert nearby
+    assert nearby[0]["id"] == "2"
+    assert all(isinstance(k, str) for k in nearby[0].keys())
+

--- a/xwe/world/location_manager.py
+++ b/xwe/world/location_manager.py
@@ -214,7 +214,7 @@ class LocationManager:
             area = self.world_map.get_area(area_id)
             if area:
                 info = {
-                    'id': area.id,
+                    'id': str(area.id),
                     'name': area.name,
                     'type': area.type.value,
                     'danger_level': area.danger_level,

--- a/xwe/world/world_map.py
+++ b/xwe/world/world_map.py
@@ -86,21 +86,21 @@ class Area:
         """从字典创建"""
         area_type = AreaType(data.get('type', 'wilderness'))
         return cls(
-            id=data['id'],
+            id=str(data['id']),
             name=data['name'],
             type=area_type,
             description=data.get('description', ''),
-            parent_region=data.get('parent_region', ''),
+            parent_region=str(data.get('parent_region', '')),
             danger_level=data.get('danger_level', 1),
             min_level_requirement=data.get('min_level_requirement', 0),
             features=data.get('features', []),
             resources=data.get('resources', {}),
-            connected_areas=data.get('connected_areas', []),
+            connected_areas=[str(a) for a in data.get('connected_areas', [])],
             available_actions=data.get('available_actions', []),
             is_discovered=data.get('is_discovered', False),
             is_accessible=data.get('is_accessible', True),
-            npcs=data.get('npcs', []),
-            events=data.get('events', []),
+            npcs=[str(n) for n in data.get('npcs', [])],
+            events=[str(e) for e in data.get('events', [])],
             extra_data=data.get('extra_data', {})
         )
 
@@ -128,11 +128,11 @@ class Region:
     def from_dict(cls, data: Dict[str, Any]) -> 'Region':
         """从字典创建"""
         return cls(
-            id=data['id'],
+            id=str(data['id']),
             name=data['name'],
             description=data.get('description', ''),
             controlling_force=data.get('controlling_force', ''),
-            sub_areas=data.get('sub_areas', [])
+            sub_areas=[str(a) for a in data.get('sub_areas', [])]
         )
 
 
@@ -276,7 +276,7 @@ class WorldMap:
             return {}
         
         info: Dict[str, Any] = {
-            'id': area.id,
+            'id': str(area.id),
             'name': area.name,
             'type': area.type.value,
             'description': area.description if area.is_discovered else "未知区域",
@@ -307,7 +307,7 @@ class WorldMap:
         """获取所有大区域信息"""
         return [
             {
-                'id': region.id,
+                'id': str(region.id),
                 'name': region.name,
                 'description': region.description,
                 'controlling_force': region.controlling_force,


### PR DESCRIPTION
## Summary
- ensure Area.from_dict and Region.from_dict cast IDs to strings
- return string IDs from map info helpers
- adjust nearby area helper to output string IDs
- add unit tests for these helper methods

## Testing
- `pytest tests/unit/test_world_map_info.py -q`
- `pytest tests/ -v` *(fails: ModuleNotFoundError for run_web_ui, SyntaxError in tests/unit/test_api.py)*

------
https://chatgpt.com/codex/tasks/task_e_684a8f029b188328b0603cf70bf19bd4