### PR TITLE
Fix var-annotated hints

### DIFF
--- a/xwe/features/technical_ops.py
+++ b/xwe/features/technical_ops.py
@@ -396,17 +396,10 @@ class ErrorHandler:
         
         # 错误统计
         self.error_counts: Dict[str, int] = {}
-
-        self.last_errors: List[str] = []
-
         self.last_errors: List[ErrorLog] = []
-
         self.max_recent_errors = 100
 
         # 错误处理回调
-
-        self.error_callbacks: List[Callable[[Exception], None]] = []
-
         self.error_callbacks: List[Callable[[ErrorLog], Any]] = []
 
     

--- a/xwe/services/combat_service.py
+++ b/xwe/services/combat_service.py
@@ -55,8 +55,6 @@ class CombatService(ServiceBase[ICombatService], ICombatService):
 
         self._combat_log: List[Dict[str, Any]] = []
 
-        self._combat_log: List[str] = []
-
         
     def start_combat(self, enemy_data: Dict[str, Any]) -> bool:
         """开始战斗"""

--- a/xwe/services/game_service.py
+++ b/xwe/services/game_service.py
@@ -89,8 +89,6 @@ class GameService(ServiceBase[IGameService], IGameService):
         self._in_combat = False
         self._current_location = "天南镇"
 
-        self._logs: List[str] = []
-
         self._logs: List[Dict[str, Any]] = []
 
         self._events: List[Dict[str, Any]] = []

--- a/xwe/services/world_service.py
+++ b/xwe/services/world_service.py
@@ -56,10 +56,7 @@ class WorldService(ServiceBase[IWorldService], IWorldService):
         super().__init__(container)
         self._locations: Dict[str, Dict[str, Any]] = {}
         self._connections: Dict[str, List[str]] = {}
- 
         self._discovered_locations: Set[str] = set()
- 
-        self._discovered_locations: set[str] = set()
  
         
     def _do_initialize(self) -> None:


### PR DESCRIPTION
## Summary
- remove duplicate attribute definitions that confused mypy
- keep explicit type hints for combat, game, and world services

## Testing
- `mypy api/ xwe/ --config-file mypy.ini`

------
https://chatgpt.com/codex/tasks/task_e_684a8efead488328a20cbadf11d18c6f