### PR TITLE
Remove redundant variable declarations

### DIFF
--- a/xwe/features/technical_ops.py
+++ b/xwe/features/technical_ops.py
@@ -397,15 +397,11 @@ class ErrorHandler:
         # 错误统计
         self.error_counts: Dict[str, int] = {}
 
-        self.last_errors: List[str] = []
-
         self.last_errors: List[ErrorLog] = []
 
         self.max_recent_errors = 100
 
         # 错误处理回调
-
-        self.error_callbacks: List[Callable[[Exception], None]] = []
 
         self.error_callbacks: List[Callable[[ErrorLog], Any]] = []
 

--- a/xwe/services/combat_service.py
+++ b/xwe/services/combat_service.py
@@ -53,8 +53,6 @@ class CombatService(ServiceBase[ICombatService], ICombatService):
         self._in_combat = False
         self._current_enemy = None
 
-        self._combat_log: List[Dict[str, Any]] = []
-
         self._combat_log: List[str] = []
 
         

--- a/xwe/services/game_service.py
+++ b/xwe/services/game_service.py
@@ -89,8 +89,6 @@ class GameService(ServiceBase[IGameService], IGameService):
         self._in_combat = False
         self._current_location = "天南镇"
 
-        self._logs: List[str] = []
-
         self._logs: List[Dict[str, Any]] = []
 
         self._events: List[Dict[str, Any]] = []

--- a/xwe/services/world_service.py
+++ b/xwe/services/world_service.py
@@ -59,8 +59,6 @@ class WorldService(ServiceBase[IWorldService], IWorldService):
  
         self._discovered_locations: Set[str] = set()
  
-        self._discovered_locations: set[str] = set()
- 
         
     def _do_initialize(self) -> None:
         """初始化服务"""


### PR DESCRIPTION
## Summary
- cleanup duplicate variable definitions for logs
- cleanup duplicate combat log declaration
- cleanup world service discovered locations
- cleanup technical ops error handling

## Testing
- `pip install -r requirements.txt`
- `pytest tests/ -v` *(fails: SyntaxError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_684a8efaeefc8328a191f0c9017cf2fe