### PR TITLE
修复测试导入路径

### DIFF
--- a/run_web_ui_optimized.py
+++ b/run_web_ui_optimized.py
@@ -7,8 +7,6 @@ import os
 import sys
 from pathlib import Path
 
-import app
-
 # 添加项目根目录到Python路径
 project_root = Path(__file__).parent
 sys.path.insert(0, str(project_root))
@@ -26,11 +24,11 @@ from xwe.features.ai_personalization import AIPersonalization
 from xwe.features.community_system import CommunitySystem
 from xwe.features.technical_ops import TechnicalOps
 from api import register_api
-register_api(app)
 
 
 app = Flask(__name__, static_folder='static', template_folder='templates_enhanced')
 app.secret_key = 'xianxia_world_secret_key_2025'
+register_api(app)
 
 # 全局游戏实例管理
 game_instances = {}

--- a/tests/test_web_ui.py
+++ b/tests/test_web_ui.py
@@ -1,14 +1,15 @@
-from run_web_ui import app as simple_app
-from run_web_ui import app as enhanced_app
+"""Web UI 测试"""
+
+from run_web_ui_optimized import app
 
 
 def test_simple_web_ui():
-    with simple_app.test_client() as client:
+    with app.test_client() as client:
         resp = client.get('/')
         assert resp.status_code == 200
 
 
 def test_enhanced_web_ui():
-    with enhanced_app.test_client() as client:
+    with app.test_client() as client:
         resp = client.get('/status')
         assert resp.status_code == 200

--- a/tests/unit/test_api.py
+++ b/tests/unit/test_api.py
@@ -210,9 +210,12 @@ def test_error_handling():
     tester.test_endpoint('GET', '/invalid/endpoint', expected_status=404)
     
     # 测试无效的请求数据
-    tester.test_endpoint('POST', '/game/command', 
-                        data: Dict[str, Any] = {},  # 缺少required字段
-                        expected_status=400)
+    tester.test_endpoint(
+        'POST',
+        '/game/command',
+        data={},  # 缺少required字段
+        expected_status=400,
+    )
     
     # 测试无效的命令
     tester.test_endpoint('POST', '/game/command',


### PR DESCRIPTION
## 总结
- 调整 `run_web_ui_optimized.py` 初始化顺序，先创建 `Flask` 应用再注册 API
- 更新 `tests/test_web_ui.py` 引用新入口文件
- 修复 `tests/unit/test_api.py` 中的语法错误

## Testing
- `pytest --maxfail=1 -x -v`

------
https://chatgpt.com/codex/tasks/task_e_684a8f012be88328a7901eaafb1c8fd4