### PR TITLE
Update data_path type hints

### DIFF
--- a/game_config.py
+++ b/game_config.py
@@ -4,6 +4,7 @@
 
 import os
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Optional, Any
 
 
@@ -31,7 +32,7 @@ class GameConfig:
     auto_save_interval: int = 300  # 秒
     
     # 路径设置
-    data_path: str = "xwe/data"
+    data_path: str | Path | None = "xwe/data"
     save_path: str = "saves"
     log_path: str = "logs"
     
@@ -41,6 +42,12 @@ class GameConfig:
         if not self.deepseek_api_key:
             self.deepseek_api_key = os.getenv('DEEPSEEK_API_KEY', '')
         
+        # 将数据路径转换为 Path
+        if self.data_path is not None:
+            self.data_path = Path(self.data_path)
+            if not self.data_path.exists():
+                os.makedirs(self.data_path, exist_ok=True)
+
         # 确保路径存在
         for path_attr in ['save_path', 'log_path']:
             path = getattr(self, path_attr)

--- a/xwe/core/data_loader.py
+++ b/xwe/core/data_loader.py
@@ -7,7 +7,7 @@
 
 import json
 import os
-from typing import Dict, Any, Optional
+from typing import Dict, Any
 from pathlib import Path
 import logging
 
@@ -21,7 +21,7 @@ class DataLoader:
     负责加载所有JSON配置文件并提供访问接口。
     """
     
-    def __init__(self, data_path: str = None):
+    def __init__(self, data_path: str | Path | None = None):
         """
         初始化数据加载器
         
@@ -32,7 +32,7 @@ class DataLoader:
             # 默认使用相对路径
             current_dir = Path(__file__).parent.parent
             data_path = current_dir / "data"
-        
+
         self.data_path = Path(data_path)
         self.cache: Dict[str, Any] = {}
         

--- a/xwe/core/game_core.py
+++ b/xwe/core/game_core.py
@@ -7,6 +7,7 @@
 
 import logging
 from typing import Dict, Any, Optional, List
+from pathlib import Path
 from dataclasses import dataclass, field
 import json
 import os
@@ -83,7 +84,7 @@ class GameCore:
     管理所有游戏系统和主循环。
     """
     
-    def __init__(self, data_path: Optional[str] = None):
+    def __init__(self, data_path: str | Path | None = None):
         """
         初始化游戏核心
         


### PR DESCRIPTION
## Summary
- allow `data_path` to be `str | Path | None`
- keep `data_path` stored as `Path`
- support the new parameter type in `GameCore`

## Testing
- `python -m mypy --exclude archive --exclude backup_20250611_204502 --exclude backup_20250610_094231 .`

------
https://chatgpt.com/codex/tasks/task_e_684ac72d98f48328a85a649b2e0b4f25