### PR TITLE
Fix fallback VisualEnhancement handling

### DIFF
--- a/xwe/features/auction_system.py
+++ b/xwe/features/auction_system.py
@@ -12,23 +12,29 @@
 import json
 import random
 import time
-from typing import Dict, List, Optional, Tuple, Any
+from typing import Dict, List, Optional, Tuple, Any, Type, Any as AnyType
 from pathlib import Path
 from enum import Enum
 from dataclasses import dataclass, field
 
 from xwe.core.data_loader import DataLoader
+
+VEClass: Type[AnyType]
 try:
     from xwe.features.visual_enhancement import VisualEnhancement
 except Exception:  # pragma: no cover - fallback
     from xwe.features.visual_enhancement import visual_effects
 
-    class VisualEnhancement:
-        def __init__(self):
+    class _FallbackVisualEnhancement:
+        def __init__(self) -> None:
             self._effects = visual_effects
 
         def get_colored_text(self, text: str, color: str) -> str:
             return self._effects.text_renderer.colorize(text, color.lower())
+
+    VEClass = _FallbackVisualEnhancement
+else:
+    VEClass = VisualEnhancement
 
 
 class AuctionMode(Enum):
@@ -80,7 +86,7 @@ class AuctionSystem:
     def __init__(self):
         """初始化拍卖系统"""
         self.data_loader = DataLoader()
-        self.visual = VisualEnhancement()
+        self.visual = VEClass()
         
         # 加载配置数据
         self._load_auction_data()

--- a/xwe/features/interactive_auction.py
+++ b/xwe/features/interactive_auction.py
@@ -6,19 +6,25 @@
 
 import time
 import random
-from typing import Optional, List, Dict, Any
+from typing import Optional, List, Dict, Any, Type, Any as AnyType
 from xwe.features.auction_system import AuctionSystem, AuctionItem, BidderType
+
+VEClass: Type[AnyType]
 try:
     from xwe.features.visual_enhancement import VisualEnhancement
 except Exception:  # pragma: no cover - fallback
     from xwe.features.visual_enhancement import visual_effects
 
-    class VisualEnhancement:
-        def __init__(self):
+    class _FallbackVisualEnhancement:
+        def __init__(self) -> None:
             self._effects = visual_effects
 
         def get_colored_text(self, text: str, color: str) -> str:
             return self._effects.text_renderer.colorize(text, color.lower())
+
+    VEClass = _FallbackVisualEnhancement
+else:
+    VEClass = VisualEnhancement
 
 
 class InteractiveAuction:
@@ -26,7 +32,7 @@ class InteractiveAuction:
     
     def __init__(self, auction_system: AuctionSystem):
         self.auction_system = auction_system
-        self.visual = VisualEnhancement()
+        self.visual = VEClass()
         self.current_item = None
         self.bidding_active = False
         self.countdown_active = False


### PR DESCRIPTION
## Summary
- avoid redefining `VisualEnhancement` by introducing `VEClass` alias
- rename fallback classes to `_FallbackVisualEnhancement`
- use the alias to instantiate visual helpers when imports fail

## Testing
- `mypy api/ xwe/ --config-file mypy.ini`
- `pytest tests/ -v`

------
https://chatgpt.com/codex/tasks/task_e_684ac733dfbc83289447d9b33788d926