### PR TITLE
Fix variable shadowing in command suggestions

### DIFF
--- a/xwe/core/command_parser.py
+++ b/xwe/core/command_parser.py
@@ -400,9 +400,9 @@ class CommandParser:
             "地图", "帮助"
         ]
         
-        for cmd in basic_commands:
-            if cmd.startswith(partial_text):
-                suggestions.append(cmd)
+        for cmd_str in basic_commands:
+            if cmd_str.startswith(partial_text):
+                suggestions.append(cmd_str)
         
         # 从历史中学习
         for cmd in self.command_history[-10:]:  # 最近10条


### PR DESCRIPTION
## Summary
- rename loop variable in command suggestions to avoid mixing `str` and `ParsedCommand`

## Testing
- `mypy xwe/core/command_parser.py --ignore-missing-imports --follow-imports skip`
- `pytest tests/ -v`

------
https://chatgpt.com/codex/tasks/task_e_684ac72b6cd48328860fc611d442f431