### PR TITLE
Fix event system syntax and init imports

### DIFF
--- a/xwe/core/__init__.py
+++ b/xwe/core/__init__.py
@@ -3,6 +3,8 @@
 XWE核心游戏系统模块
 """
 
+from typing import Any, Dict
+
 from .data_loader import DataLoader
 from .attributes import AttributeSystem, CharacterAttributes
 from .character import Character

--- a/xwe/world/event_system.py
+++ b/xwe/world/event_system.py
@@ -335,7 +335,7 @@ class EventSystem:
                 EventChoice(
                     id="leave",
                     text="礼貌拒绝",
-                    consequences: Dict[str, Any] = {}
+                    consequences={}
                 )
             ],
             repeatable=True,


### PR DESCRIPTION
## Summary
- fix `EventChoice` syntax error in the mysterious merchant event
- add missing `typing` imports in `xwe.core`

## Testing
- `pytest tests/ -v`

------
https://chatgpt.com/codex/tasks/task_e_684acd40bf5c8328bca3547ea02dd844