### PR TITLE
Update sidebar styling and unify colors

### DIFF
--- a/templates_enhanced/components/game_panels.html
+++ b/templates_enhanced/components/game_panels.html
@@ -240,14 +240,14 @@
 /* 游戏面板通用样式 */
 .game-panel {
     background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
-    border: 2px solid #c9b037;
+    border: 2px solid #6b8b7d;
     border-radius: 10px;
     width: 90%;
     max-width: 600px;
     max-height: 80vh;
     display: flex;
     flex-direction: column;
-    box-shadow: 0 0 30px rgba(201, 176, 55, 0.3);
+    box-shadow: 0 0 30px rgba(107, 139, 125, 0.3);
     animation: slideIn 0.3s ease;
 }
 
@@ -268,7 +268,7 @@
 /* 面板头部 */
 .panel-header {
     padding: 15px 20px;
-    border-bottom: 1px solid rgba(201, 176, 55, 0.3);
+    border-bottom: 1px solid rgba(107, 139, 125, 0.3);
     display: flex;
     justify-content: space-between;
     align-items: center;
@@ -276,14 +276,14 @@
 
 .panel-header h3 {
     margin: 0;
-    color: #c9b037;
+    color: #6b8b7d;
     font-size: 20px;
 }
 
 .panel-close {
     background: none;
     border: none;
-    color: #c9b037;
+    color: #6b8b7d;
     font-size: 24px;
     cursor: pointer;
     opacity: 0.7;
@@ -318,12 +318,12 @@
 }
 
 .status-item label {
-    color: #c9b037;
+    color: #6b8b7d;
     font-weight: bold;
 }
 
 .status-item span {
-    color: #f4e7c1;
+    color: #d5e5d3;
 }
 
 /* 背包样式 */
@@ -337,7 +337,7 @@
 .inventory-slot {
     aspect-ratio: 1;
     background: rgba(0, 0, 0, 0.5);
-    border: 1px solid rgba(201, 176, 55, 0.3);
+    border: 1px solid rgba(107, 139, 125, 0.3);
     border-radius: 5px;
     cursor: pointer;
     position: relative;
@@ -348,20 +348,20 @@
 }
 
 .inventory-slot:hover {
-    border-color: #c9b037;
-    background: rgba(201, 176, 55, 0.1);
+    border-color: #6b8b7d;
+    background: rgba(107, 139, 125, 0.1);
 }
 
 .item-info {
     padding: 15px;
     background: rgba(0, 0, 0, 0.5);
     border-radius: 5px;
-    border: 1px solid rgba(201, 176, 55, 0.3);
+    border: 1px solid rgba(107, 139, 125, 0.3);
 }
 
 .item-info h4 {
     margin: 0 0 10px 0;
-    color: #c9b037;
+    color: #6b8b7d;
 }
 
 /* 修炼系统样式 */
@@ -370,7 +370,7 @@
 }
 
 .cultivation-section h4 {
-    color: #c9b037;
+    color: #6b8b7d;
     margin: 0 0 15px 0;
 }
 
@@ -384,11 +384,11 @@
 
 .technique-name {
     font-weight: bold;
-    color: #f4e7c1;
+    color: #d5e5d3;
 }
 
 .technique-progress {
-    color: #c9b037;
+    color: #6b8b7d;
 }
 
 .technique-list {
@@ -406,7 +406,7 @@
 }
 
 .technique-item:hover {
-    background: rgba(201, 176, 55, 0.1);
+    background: rgba(107, 139, 125, 0.1);
 }
 
 .cultivation-input {
@@ -419,14 +419,14 @@
     width: 80px;
     padding: 5px;
     background: rgba(0, 0, 0, 0.5);
-    border: 1px solid rgba(201, 176, 55, 0.3);
+    border: 1px solid rgba(107, 139, 125, 0.3);
     color: #e0e0e0;
     border-radius: 3px;
 }
 
 .cultivation-input button {
     padding: 5px 15px;
-    background: #c9b037;
+    background: #6b8b7d;
     color: #1a1a2e;
     border: none;
     border-radius: 5px;
@@ -435,7 +435,7 @@
 }
 
 .cultivation-tip {
-    color: #f4e7c1;
+    color: #d5e5d3;
     margin-bottom: 10px;
 }
 
@@ -452,19 +452,19 @@
 }
 
 .achievement-table th {
-    background: rgba(201, 176, 55, 0.2);
-    color: #c9b037;
+    background: rgba(107, 139, 125, 0.2);
+    color: #6b8b7d;
     padding: 10px;
     text-align: left;
 }
 
 .achievement-table td {
     padding: 10px;
-    border-bottom: 1px solid rgba(201, 176, 55, 0.1);
+    border-bottom: 1px solid rgba(107, 139, 125, 0.1);
 }
 
 .achievement-table tr:hover {
-    background: rgba(201, 176, 55, 0.05);
+    background: rgba(107, 139, 125, 0.05);
 }
 
 /* 探索面板样式 */
@@ -472,7 +472,7 @@
     display: block;
     margin: 20px auto;
     padding: 15px 30px;
-    background: linear-gradient(135deg, #c9b037 0%, #f4e7c1 100%);
+    background: linear-gradient(135deg, #6b8b7d 0%, #d5e5d3 100%);
     color: #1a1a2e;
     border: none;
     border-radius: 25px;
@@ -484,7 +484,7 @@
 
 .explore-btn:hover {
     transform: translateY(-2px);
-    box-shadow: 0 5px 20px rgba(201, 176, 55, 0.3);
+    box-shadow: 0 5px 20px rgba(107, 139, 125, 0.3);
 }
 
 .explore-result {
@@ -513,12 +513,12 @@
     padding: 15px;
     background: rgba(0, 0, 0, 0.3);
     border-radius: 5px;
-    border-left: 3px solid #c9b037;
+    border-left: 3px solid #6b8b7d;
 }
 
 .quest-item h5 {
     margin: 0 0 10px 0;
-    color: #c9b037;
+    color: #6b8b7d;
 }
 
 .quest-item p {
@@ -545,12 +545,12 @@
 }
 
 .save-btn {
-    background: #4caf50;
+    background: #6b8b7d;
     color: white;
 }
 
 .load-btn {
-    background: #2196f3;
+    background: #6b8b7d;
     color: white;
 }
 
@@ -562,12 +562,12 @@
 .save-load-message {
     text-align: center;
     padding: 15px;
-    color: #c9b037;
+    color: #6b8b7d;
 }
 
 /* 帮助文档样式 */
 .help-content h4 {
-    color: #c9b037;
+    color: #6b8b7d;
     margin: 20px 0 10px 0;
 }
 
@@ -582,10 +582,10 @@
 }
 
 .help-content code {
-    background: rgba(201, 176, 55, 0.2);
+    background: rgba(107, 139, 125, 0.2);
     padding: 2px 5px;
     border-radius: 3px;
-    color: #f4e7c1;
+    color: #d5e5d3;
 }
 
 /* 滚动条 */
@@ -598,7 +598,7 @@
 }
 
 .panel-body::-webkit-scrollbar-thumb {
-    background: rgba(201, 176, 55, 0.5);
+    background: rgba(107, 139, 125, 0.5);
     border-radius: 4px;
 }
 
@@ -777,7 +777,7 @@ const GamePanels = {
         
         // 功法列表
         const techniques = [
-            { name: '青云诀', level: '黄阶下品', color: '#c9b037' },
+            { name: '青云诀', level: '黄阶下品', color: '#6b8b7d' },
             { name: '烈火诀', level: '黄阶中品', color: '#ff9800' },
             { name: '寒冰诀', level: '黄阶中品', color: '#03a9f4' }
         ];
@@ -833,7 +833,7 @@ const GamePanels = {
                 <ul>
                     <li><a href="#" onclick="GamePanels.travelTo('青云城')">青云城</a> - 繁华的修真城市</li>
                     <li><a href="#" onclick="GamePanels.travelTo('青云峰')">青云峰</a> - 青云宗山门</li>
-                    <li><a href="#" onclick="GamePanels.travelTo('灵兽森林')">灵兽森林<span style="color: #c9b037">(新)</span></a> - 危险的森林</li>
+                    <li><a href="#" onclick="GamePanels.travelTo('灵兽森林')">灵兽森林<span style="color: #6b8b7d">(新)</span></a> - 危险的森林</li>
                 </ul>
             </div>
         `;
@@ -857,7 +857,7 @@ const GamePanels = {
             item.innerHTML = `
                 <h5>${quest.name}</h5>
                 <p>${quest.desc}</p>
-                <p style="color: #c9b037">状态：${quest.progress}</p>
+                <p style="color: #6b8b7d">状态：${quest.progress}</p>
             `;
             list.appendChild(item);
         });
@@ -890,7 +890,7 @@ const GamePanels = {
         result.innerHTML = '<p>正在探索中...</p>';
         
         setTimeout(() => {
-            result.innerHTML = '<p>你在附近发现了一株<span style="color: #c9b037">百年人参</span>！</p>';
+            result.innerHTML = '<p>你在附近发现了一株<span style="color: #6b8b7d">百年人参</span>！</p>';
         }, 1000);
     },
     
@@ -915,7 +915,7 @@ const GamePanels = {
             const msg = document.getElementById('saveLoadMessage');
             if (data.success) {
                 msg.textContent = '游戏保存成功！';
-                msg.style.color = '#4caf50';
+                msg.style.color = '#6b8b7d';
             } else {
                 msg.textContent = '保存失败：' + data.error;
                 msg.style.color = '#f44336';
@@ -936,7 +936,7 @@ const GamePanels = {
             const msg = document.getElementById('saveLoadMessage');
             if (data.success) {
                 msg.textContent = '游戏加载成功！';
-                msg.style.color = '#4caf50';
+                msg.style.color = '#6b8b7d';
                 // 刷新游戏状态
                 if (typeof GameUI !== 'undefined' && GameUI.refreshStatus) {
                     GameUI.refreshStatus();

--- a/templates_enhanced/components/sidebar_v2.html
+++ b/templates_enhanced/components/sidebar_v2.html
@@ -11,56 +11,57 @@
             <span class="realm-progress" id="realmProgress">(0%)</span>
         </div>
     </div>
-    
+
+    <div class="location-info">
+        <span id="currentLocation">青云城</span>
+    </div>
+
     <!-- 生命值和灵力值 -->
     <div class="status-bars">
         <div class="status-bar-item">
             <label>气血</label>
             <div class="status-bar">
                 <div class="status-bar-fill health-bar" id="healthBar" style="width: 100%"></div>
-                <span class="status-text" id="healthText">100/100</span>
             </div>
+            <span class="status-text" id="healthText">100/100</span>
         </div>
-        
+
         <div class="status-bar-item">
             <label>灵力</label>
             <div class="status-bar">
                 <div class="status-bar-fill mana-bar" id="manaBar" style="width: 100%"></div>
-                <span class="status-text" id="manaText">50/50</span>
             </div>
+            <span class="status-text" id="manaText">50/50</span>
         </div>
     </div>
-    
+
     <!-- 功能链接面板 -->
     <div class="function-panel">
         <table class="function-table">
             <tr>
                 <td><a href="#" onclick="GamePanels.showStatus()">查看状态</a></td>
                 <td><a href="#" onclick="GamePanels.showInventory()">查看背包</a></td>
-                <td><a href="#" onclick="GamePanels.showCultivation()">修炼系统</a></td>
             </tr>
             <tr>
+                <td><a href="#" onclick="GamePanels.showCultivation()">修炼系统</a></td>
                 <td><a href="#" onclick="GamePanels.showAchievements()">成就系统</a></td>
+            </tr>
+            <tr>
                 <td><a href="#" onclick="GamePanels.showExplore()">进行探索</a></td>
                 <td><a href="#" onclick="GamePanels.showMap()">地图系统</a></td>
             </tr>
             <tr>
                 <td><a href="#" onclick="GamePanels.showQuests()">当前任务</a></td>
                 <td><a href="#" onclick="GamePanels.showSaveLoad()">保存加载</a></td>
-                <td><a href="#" onclick="GamePanels.showHelp()">帮助文档</a></td>
+            </tr>
+            <tr>
+                <td colspan="2"><a href="#" onclick="GamePanels.showHelp()">帮助文档</a></td>
             </tr>
         </table>
-    </div>
-    
-    <!-- 当前位置 -->
-    <div class="location-info">
-        <label>当前位置</label>
-        <span id="currentLocation">{{ location if location else '未知' }}</span>
     </div>
 </div>
 
 <style>
-/* 基于舊版樣式調整 */
 .sidebar {
     width: 280px;
     padding: 25px 20px;
@@ -73,7 +74,6 @@
     -webkit-overflow-scrolling: touch;
 }
 
-/* 角色信息 */
 .character-info {
     text-align: center;
     padding-bottom: 20px;
@@ -106,7 +106,13 @@
     font-size: 16px;
 }
 
-/* 状态条 */
+.location-info {
+    margin: 10px 0;
+    text-align: center;
+    color: #d8d8d8;
+    font-weight: bold;
+}
+
 .status-bars {
     display: flex;
     flex-direction: column;
@@ -126,7 +132,6 @@
 }
 
 .status-bar {
-    position: relative;
     width: 100%;
     height: 4px;
     background: rgba(100, 100, 100, 0.2);
@@ -139,7 +144,6 @@
     height: 100%;
     background: linear-gradient(90deg, rgba(200, 200, 200, 0.6), rgba(255, 255, 255, 0.4));
     transition: width 0.3s ease;
-    position: relative;
 }
 
 .health-bar {
@@ -150,32 +154,20 @@
     background: linear-gradient(90deg, rgba(100, 150, 255, 0.6), rgba(150, 180, 255, 0.4));
 }
 
-.status-bar-fill::after {
-    content: '';
-    position: absolute;
-    top: 0;
-    left: 0;
-    right: 0;
-    height: 100%;
-    background: none;
-}
-
 .status-text {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
     color: #d8d8d8;
     font-size: 12px;
     font-weight: bold;
+    text-align: center;
+    margin-top: 4px;
 }
 
-/* 功能面板 */
 .function-panel {
     background: rgba(0, 0, 0, 0.3);
     border: 1px solid rgba(200, 200, 200, 0.1);
     border-radius: 8px;
     padding: 15px;
+    margin-top: 20px;
 }
 
 .function-table {
@@ -184,6 +176,7 @@
 }
 
 .function-table td {
+    width: 50%;
     padding: 8px;
     text-align: center;
 }
@@ -202,29 +195,6 @@
     color: #d8d8d8;
 }
 
-/* 位置信息 */
-.location-info {
-    margin-top: auto;
-    padding: 15px;
-    background: rgba(0, 0, 0, 0.3);
-    border-radius: 8px;
-    text-align: center;
-}
-
-.location-info label {
-    display: block;
-    color: #888;
-    font-size: 14px;
-    margin-bottom: 5px;
-}
-
-.location-info span {
-    color: #d8d8d8;
-    font-size: 16px;
-    font-weight: bold;
-}
-
-/* 滚动条 */
 .sidebar::-webkit-scrollbar {
     width: 6px;
 }
@@ -238,7 +208,6 @@
     border-radius: 3px;
 }
 
-/* 响应式 */
 @media (max-width: 768px) {
     .sidebar {
         width: 100%;
@@ -246,11 +215,11 @@
         border-right: none;
         border-bottom: none;
     }
-    
+
     .function-table {
         font-size: 12px;
     }
-    
+
     .function-table td {
         padding: 5px;
     }


### PR DESCRIPTION
## Summary
- modernize sidebar_v2 layout and move location section
- show HP/MP numbers outside bars
- switch function panel to two-column layout
- refresh panel color scheme to soft gray-green

## Testing
- `pip install -r requirements.txt`
- `pytest tests/ -v`

------
https://chatgpt.com/codex/tasks/task_e_684b898fb90883288a45642270664a20