### PR TITLE
Reduce needless polling

### DIFF
--- a/templates/game.html
+++ b/templates/game.html
@@ -504,6 +504,7 @@
 
 </body>
     <script>
+        let lastKnownStatus = null;
         async function fetchStatus() {
             const res = await fetch('/status');
             const data = await res.json();
@@ -539,11 +540,21 @@
         }
 
         async function checkUpdates() {
-            const res = await fetch('/need_refresh');
-            const data = await res.json();
-            if (data.refresh) {
-                fetchLog();
-                fetchStatus();
+            try {
+                const res = await fetch('/need_refresh');
+                if (!res.ok) return;
+
+                const data = await res.json();
+                if (JSON.stringify(data) !== JSON.stringify(lastKnownStatus)) {
+                    lastKnownStatus = data;
+
+                    if (data.refresh) {
+                        fetchLog();
+                        fetchStatus();
+                    }
+                }
+            } catch (err) {
+                console.warn('轮询失败:', err);
             }
         }
 
@@ -677,7 +688,7 @@
             document.getElementById('mana').title = '当前灵力值/上限';
             document.getElementById('attack').title = '决定造成伤害的高低';
             document.getElementById('defense').title = '降低受到的伤害';
-            setInterval(throttledCheck, 1000);
+            setInterval(throttledCheck, 5000);
         }
         window.onload = init;
     </script>

--- a/templates_enhanced/game_enhanced.html
+++ b/templates_enhanced/game_enhanced.html
@@ -710,6 +710,8 @@
             achievementTotal: 20
         };
 
+        let lastKnownStatus = null;
+
         // 可用命令列表（与服务器同步）
         const availableCommands = [
             { cmd: '状态', desc: '查看角色状态', shortcut: 's' },
@@ -1029,13 +1031,18 @@
         async function checkUpdates() {
             try {
                 const res = await fetch('/need_refresh');
+                if (!res.ok) return;
+
                 const data = await res.json();
-                if (data.refresh) {
-                    fetchLog();
-                    fetchStatus();
+                if (JSON.stringify(data) !== JSON.stringify(lastKnownStatus)) {
+                    lastKnownStatus = data;
+                    if (data.refresh) {
+                        fetchLog();
+                        fetchStatus();
+                    }
                 }
             } catch (e) {
-                console.error('检查更新失败:', e);
+                console.warn('检查更新失败:', e);
             }
         }
 
@@ -1178,7 +1185,7 @@
             updateAchievementDisplay();
             
             // 定期检查更新
-            setInterval(checkUpdates, 3000);
+            setInterval(checkUpdates, 5000);
             
             // 定期随机事件
             setInterval(() => {

--- a/templates_enhanced/game_enhanced_optimized.html
+++ b/templates_enhanced/game_enhanced_optimized.html
@@ -813,6 +813,8 @@
             lastUpdateTime: 0
         };
 
+        let lastKnownStatus = null;
+
         // 可用命令列表（与服务器同步）
         const availableCommands = [
             { cmd: '状态', desc: '查看角色状态', shortcut: 's' },
@@ -1321,19 +1323,22 @@
         async function checkUpdates() {
             // 如果用户正在交互，跳过自动刷新
             if (gameState.isUserInteracting) return;
-            
+
             try {
                 const res = await fetch('/need_refresh');
                 if (!res.ok) return;
-                
+
                 const data = await res.json();
-                if (data.refresh && data.last_update > gameState.lastUpdateTime) {
-                    gameState.lastUpdateTime = data.last_update;
-                    await fetchLog();
-                    await fetchStatus();
+                if (JSON.stringify(data) !== JSON.stringify(lastKnownStatus)) {
+                    lastKnownStatus = data;
+                    if (data.refresh && data.last_update > gameState.lastUpdateTime) {
+                        gameState.lastUpdateTime = data.last_update;
+                        await fetchLog();
+                        await fetchStatus();
+                    }
                 }
             } catch (error) {
-                console.error('检查更新失败:', error);
+                console.warn('检查更新失败:', error);
             }
         }
 


### PR DESCRIPTION
## Summary
- add `lastKnownStatus` cache to avoid redundant refreshes
- throttle checkUpdates failures with console warnings
- lengthen refresh interval in embedded HTML templates

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_684be9a251948328b99d766d537a95c9