### PR TITLE
Fix stray CSS text in sidebar

### DIFF
--- a/templates_enhanced/components/sidebar_v2.html
+++ b/templates_enhanced/components/sidebar_v2.html
@@ -62,6 +62,8 @@
 </div>
 
 
+<style>
+
 .character-info {
     text-align: center;
     padding-bottom: 20px;


### PR DESCRIPTION
## Summary
- ensure sidebar_v2.css styles are wrapped in a `<style>` tag to prevent text output on the page

## Testing
- `pytest tests/ -v`

------
https://chatgpt.com/codex/tasks/task_e_684c177e0afc8328912f53fcfe89e9a7