### PR TITLE
Add Intelligence System and UI

### DIFF
--- a/routes/intel.py
+++ b/routes/intel.py
@@ -1,0 +1,23 @@
+"""情报系统路由"""
+
+from flask import Blueprint, jsonify, session
+
+from xwe.features.intelligence_system import intelligence_system
+import run_web_ui_optimized
+
+bp = Blueprint("intel", __name__)
+
+
+@bp.get("/api/intel")
+def get_intel():
+    """获取情报信息"""
+    if 'session_id' not in session:
+        return jsonify({'global': [], 'personal': []})
+
+    instance = run_web_ui_optimized.get_game_instance(session['session_id'])
+    game = instance['game']
+    player_id = getattr(game.game_state.player, 'id', 'player') if game.game_state.player else 'player'
+
+    global_news = [n.to_dict() for n in intelligence_system.get_global_news()]
+    personal = [n.to_dict() for n in intelligence_system.get_personal_intel(player_id)]
+    return jsonify({'global': global_news, 'personal': personal})

--- a/run_web_ui_optimized.py
+++ b/run_web_ui_optimized.py
@@ -25,7 +25,7 @@ from xwe.features.ai_personalization import AIPersonalization
 from xwe.features.community_system import CommunitySystem
 from xwe.features.technical_ops import TechnicalOps
 from api import register_api
-from routes import lore, character
+from routes import lore, character, intel
 
 
 app = Flask(__name__, static_folder='static', template_folder='templates_enhanced')
@@ -35,6 +35,7 @@ register_api(app)
 # 注册路由蓝图
 app.register_blueprint(lore.bp)
 app.register_blueprint(character.bp)
+app.register_blueprint(intel.bp)
 
 # 全局游戏实例管理
 game_instances = {}

--- a/templates_enhanced/components/game_panels.html
+++ b/templates_enhanced/components/game_panels.html
@@ -167,6 +167,21 @@
             </div>
         </div>
     </div>
+
+    <!-- 情报面板 -->
+    <div id="intelPanel" class="game-panel" style="display: none;">
+        <div class="panel-header">
+            <h3>情报</h3>
+            <button class="panel-close" onclick="GamePanels.closePanel('intelPanel')">&times;</button>
+        </div>
+        <div class="panel-body">
+            <div class="intel-tabs">
+                <button id="intelTabWorld" onclick="GamePanels.switchIntelTab('world')">世界</button>
+                <button id="intelTabPersonal" onclick="GamePanels.switchIntelTab('personal')">个人</button>
+            </div>
+            <div class="intel-list" id="intelList"></div>
+        </div>
+    </div>
     
     <!-- 保存加载面板 -->
     <div id="saveLoadPanel" class="game-panel" style="display: none;">
@@ -526,6 +541,32 @@
     color: #e0e0e0;
 }
 
+/* 情报面板样式 */
+.intel-tabs {
+    display: flex;
+    gap: 10px;
+    margin-bottom: 10px;
+}
+.intel-tabs button {
+    flex: 1;
+    padding: 8px;
+    background: rgba(0, 0, 0, 0.4);
+    border: none;
+    color: #ccc;
+    cursor: pointer;
+}
+.intel-tabs button.active {
+    background: rgba(107, 139, 125, 0.4);
+}
+.intel-item {
+    padding: 10px;
+    border-bottom: 1px solid rgba(107, 139, 125, 0.2);
+    cursor: pointer;
+}
+.intel-item:hover {
+    background: rgba(107, 139, 125, 0.1);
+}
+
 /* 保存加载样式 */
 .save-load-buttons {
     display: flex;
@@ -687,6 +728,9 @@ const GamePanels = {
             case 'questsPanel':
                 this.loadQuestsData();
                 break;
+            case 'intelPanel':
+                this.loadIntelData();
+                break;
         }
     },
     
@@ -698,6 +742,7 @@ const GamePanels = {
     showExplore() { this.showPanel('explorePanel'); },
     showMap() { this.showPanel('mapPanel'); },
     showQuests() { this.showPanel('questsPanel'); },
+    showIntel() { this.showPanel('intelPanel'); },
     showSaveLoad() { this.showPanel('saveLoadPanel'); },
     showHelp() { this.showPanel('helpPanel'); },
     
@@ -861,6 +906,41 @@ const GamePanels = {
             `;
             list.appendChild(item);
         });
+    },
+
+    /**
+     * 加载情报数据
+     */
+    async loadIntelData(tab = 'world') {
+        try {
+            const resp = await fetch('/api/intel');
+            const data = await resp.json();
+            const list = document.getElementById('intelList');
+            list.innerHTML = '';
+            const items = tab === 'world' ? data.global : data.personal;
+            items.forEach(i => {
+                const div = document.createElement('div');
+                div.className = 'intel-item';
+                div.textContent = i.title;
+                div.onclick = () => GamePanels.showIntelDetail(i);
+                list.appendChild(div);
+            });
+            document.getElementById('intelTabWorld').classList.toggle('active', tab === 'world');
+            document.getElementById('intelTabPersonal').classList.toggle('active', tab === 'personal');
+        } catch (e) {
+            console.error('加载情报失败', e);
+        }
+    },
+
+    switchIntelTab(tab) {
+        this.loadIntelData(tab);
+    },
+
+    showIntelDetail(item) {
+        alert(item.content);
+        if (item.interactable_task_id) {
+            this.showQuests();
+        }
     },
     
     /**

--- a/templates_enhanced/components/sidebar_v2.html
+++ b/templates_enhanced/components/sidebar_v2.html
@@ -52,7 +52,10 @@
             </tr>
             <tr>
                 <td><a href="#" onclick="GamePanels.showQuests()">当前任务</a></td>
-                <td><a href="#" onclick="GamePanels.showSaveLoad()">保存加载</a></td>
+                <td><a href="#" onclick="GamePanels.showIntel()">情报面板</a></td>
+            </tr>
+            <tr>
+                <td colspan="2"><a href="#" onclick="GamePanels.showSaveLoad()">保存加载</a></td>
             </tr>
             <tr>
                 <td colspan="2"><a href="#" onclick="GamePanels.showHelp()">帮助文档</a></td>

--- a/tests/test_web_ui.py
+++ b/tests/test_web_ui.py
@@ -18,3 +18,11 @@ def test_enhanced_web_ui():
     with app.test_client() as client:
         resp = client.get('/status')
         assert resp.status_code == 200
+
+
+def test_intel_api():
+    with app.test_client() as client:
+        resp = client.get('/api/intel')
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert 'global' in data and 'personal' in data

--- a/xwe/features/__init__.py
+++ b/xwe/features/__init__.py
@@ -113,6 +113,12 @@ from .auction_commands import (
     auction_command_handler
 )
 from .interactive_auction import InteractiveAuction
+from .intelligence_system import (
+    IntelItem,
+    IntelligenceSystem,
+    intelligence_system,
+    integrate_intelligence_system,
+)
 
 # 版本信息
 __version__ = "2.0.0"
@@ -154,5 +160,9 @@ __all__ = [
     # 拍卖行系统
     "auction_system",
     "auction_command_handler",
-    "InteractiveAuction"
+    "InteractiveAuction",
+    "intelligence_system",
+    "integrate_intelligence_system",
+    "IntelItem",
+    "IntelligenceSystem"
 ]

--- a/xwe/features/intelligence_system.py
+++ b/xwe/features/intelligence_system.py
@@ -1,0 +1,103 @@
+"""情报系统
+提供全球新闻和个人情报的管理接口"""
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Dict, List, Optional
+
+
+@dataclass
+class IntelItem:
+    """单条情报或新闻"""
+
+    id: str
+    title: str
+    content: str
+    ttl: int
+    category: Optional[str] = None
+    interactable_task_id: Optional[str] = None
+    created_at: datetime = field(default_factory=datetime.now)
+
+    def is_expired(self) -> bool:
+        return (datetime.now() - self.created_at).total_seconds() > self.ttl
+
+    def to_dict(self) -> Dict[str, str]:
+        return {
+            "id": self.id,
+            "title": self.title,
+            "content": self.content,
+            "ttl": self.ttl,
+            "category": self.category,
+            "interactable_task_id": self.interactable_task_id,
+            "created_at": self.created_at.isoformat(),
+        }
+
+
+class IntelligenceSystem:
+    """情报系统管理器"""
+
+    def __init__(self) -> None:
+        self.global_news: List[IntelItem] = []
+        self.personal_intel: Dict[str, List[IntelItem]] = {}
+
+    def add_global_news(self, item: IntelItem) -> None:
+        """添加全球新闻"""
+        self.global_news.append(item)
+        self._cleanup()
+
+    def add_personal_intel(self, player_id: str, item: IntelItem) -> None:
+        """为指定玩家添加个人情报"""
+        self.personal_intel.setdefault(player_id, []).append(item)
+        self._cleanup()
+
+    def get_global_news(self) -> List[IntelItem]:
+        self._cleanup()
+        return list(self.global_news)
+
+    def get_personal_intel(self, player_id: str) -> List[IntelItem]:
+        self._cleanup()
+        return list(self.personal_intel.get(player_id, []))
+
+    def _cleanup(self) -> None:
+        """清理过期情报"""
+        self.global_news = [n for n in self.global_news if not n.is_expired()]
+        empty_players = []
+        for pid, items in self.personal_intel.items():
+            valid = [i for i in items if not i.is_expired()]
+            if valid:
+                self.personal_intel[pid] = valid
+            else:
+                empty_players.append(pid)
+        for pid in empty_players:
+            self.personal_intel.pop(pid, None)
+
+
+# 全局实例
+intelligence_system = IntelligenceSystem()
+
+
+def integrate_intelligence_system(game_core) -> None:
+    """将情报系统集成到游戏核心"""
+
+    def push_global(news_data: Dict[str, str]) -> None:
+        item = IntelItem(**news_data)
+        intelligence_system.add_global_news(item)
+        game_core.output(f"【情报】{item.title}")
+
+    def push_personal(news_data: Dict[str, str], player_id: Optional[str] = None) -> None:
+        pid = player_id or getattr(game_core.game_state.player, "id", "player")
+        item = IntelItem(**news_data)
+        intelligence_system.add_personal_intel(pid, item)
+        if game_core.game_state.player and pid == game_core.game_state.player.id:
+            game_core.output(f"【密闻】{item.title}")
+
+    def wrapped_process_command(text: str) -> None:
+        intelligence_system._cleanup()
+        original_process_command(text)
+
+    original_process_command = game_core.process_command
+    game_core.process_command = wrapped_process_command
+    game_core.push_global_news = push_global
+    game_core.push_personal_intel = push_personal
+
+    game_core.output("情报系统已就绪")


### PR DESCRIPTION
## Summary
- implement `IntelligenceSystem` with global and personal intel management
- expose `/api/intel` endpoint
- integrate blueprint in web UI
- add intelligence panel with world/personal tabs
- update sidebar to open the panel
- test intelligence API

## Testing
- `pytest tests/test_web_ui.py -q`

------
https://chatgpt.com/codex/tasks/task_e_684c41d9f7fc83288a363d3cd69166bd