### PR TITLE
Add command line game mode selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ python run_game.py
 
 更多启动脚本和说明请参阅 [docs/STARTERS.md](docs/STARTERS.md)。
 
+启动主菜单示例：
+```bash
+python main_menu.py --mode player  # 默认玩家模式
+python main_menu.py --mode dev     # 开发者模式
+```
+
 ### 安装步骤
 ```bash
 # 1. 克隆项目

--- a/docs/STARTERS.md
+++ b/docs/STARTERS.md
@@ -5,7 +5,7 @@
 | 脚本 | 说明 |
 | ---- | ---- |
 | `python run_game.py` | 自动修复并启动游戏（推荐） |
-| `python main_menu.py` | 启动主菜单，可从菜单进入游戏或其他工具 |
+| `python main_menu.py [--mode dev]` | 启动主菜单，可选择玩家或开发者模式 |
 | `python main.py` | 直接运行命令行版本游戏 |
 | `python main_enhanced.py` | 含 2.0 功能的增强版，生成 `game_log.html` |
  

--- a/main_menu.py
+++ b/main_menu.py
@@ -6,6 +6,7 @@
 
 import sys
 from pathlib import Path
+import argparse
 
 # 添加项目路径
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -40,9 +41,11 @@ def show_main_menu():
     return choice
 
 
-def start_new_game():
+def start_new_game(game_mode: str) -> None:
     """普通开始游戏"""
-    game = GameCore()
+    game = GameCore(game_mode=game_mode)
+    if game_mode != "player":
+        print(f"\n[开发者模式] 当前模式: {game_mode}")
     
     # 获取玩家名字
     player_name = input("请输入你的名字: ").strip() or "无名侠客"
@@ -68,10 +71,12 @@ def start_new_game():
         print(line)
 
 
-def start_with_roll():
+def start_with_roll(game_mode: str) -> None:
     """带Roll的新游戏"""
     print("\n=== 开局Roll系统 ===")
     print("你可以无限次重置角色，直到满意为止！")
+    if game_mode != "player":
+        print(f"[开发者模式] 当前模式: {game_mode}")
     
     roller = CharacterRoller()
     
@@ -92,7 +97,7 @@ def start_with_roll():
             player_name = input("\n请输入角色名: ").strip() or character.name
             
             # 开始新游戏（会自动进入Roll流程）
-            game = GameCore()
+            game = GameCore(game_mode=game_mode)
             game.start_new_game(player_name)
             
             # 游戏主循环
@@ -157,17 +162,23 @@ def show_settings():
     input("\n按Enter返回主菜单...")
 
 
-def main():
+def main() -> None:
     """主函数"""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", default="player", help="game mode: player or dev")
+    args = parser.parse_args()
+
+    game_mode = args.mode
+
     while True:
         clear_screen()
         choice = show_main_menu()
-        
+
         if choice == '1':
-            start_new_game()
-            
+            start_new_game(game_mode)
+
         elif choice == '2':
-            start_with_roll()
+            start_with_roll(game_mode)
             
         elif choice == '3':
             test_roll_system()

--- a/xwe/core/game_core_enhanced.py
+++ b/xwe/core/game_core_enhanced.py
@@ -31,9 +31,9 @@ except Exception:  # pragma: no cover - optional dependency
     CultivationSystem = None  # type: ignore
 
 
-def create_enhanced_game(log_file: str = "game_log.html") -> GameCore:
+def create_enhanced_game(log_file: str = "game_log.html", game_mode: str = "player") -> GameCore:
     """Create a ``GameCore`` instance with enhanced output and optional systems."""
-    game = GameCore()
+    game = GameCore(game_mode=game_mode)
 
     # Integrate enhanced HTML output
     html_logger = HtmlGameLogger(log_file)


### PR DESCRIPTION
## Summary
- allow specifying `--mode` when launching main_menu.py
- store selected mode in `GameState`
- create `GameCore` with game mode and pass through enhanced creator
- auto-finish character creation in non-player mode
- document new option in README and starters guide

## Testing
- `pytest tests/ -v`

------
https://chatgpt.com/codex/tasks/task_e_684c41d007a48328b51418a752a07ae8