### PR TITLE
Update docs for new entrypoints and templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@
 ## 项目结构说明（重构于 2025-06-12）
 
 ### 主入口
-- `run_web_ui_optimized.py` - **主入口文件**，运行 Flask Web UI
+- `entrypoints/run_web_ui_optimized.py` - **主入口文件**，运行 Flask Web UI
 
 ### 目录结构
 - `xwe/` - 核心游戏引擎模块
+- `xwe/data/restructured/` - 统一的数据模板目录
 - `templates/` - Flask 模板文件
 - `static/` - 静态资源文件
 - `scripts/` - 辅助脚本和示例代码

--- a/RESTRUCTURE_GUIDE.md
+++ b/RESTRUCTURE_GUIDE.md
@@ -61,6 +61,7 @@ python restructure_project.py --project-root /path/to/xianxia_world_engine
 - `scripts/tools/` - 项目工具脚本
 - `docs/progress/` - 开发进度文档
 - `docs/guides/` - 使用指南文档
+- `xwe/data/restructured/` - 统一的数据模板目录
 - `output/` - 输出文件
 
 ### 文件移动
@@ -86,6 +87,7 @@ python restructure_project.py --project-root /path/to/xianxia_world_engine
 ### 清理操作
 - 删除所有 `__pycache__` 目录
 - 删除所有 `.pyc` 文件
+- 运行 `auto_archive.py` 自动归档并删除旧备份
 
 ### README 更新
 - 自动在 README.md 中添加项目结构说明

--- a/docs/STARTERS.md
+++ b/docs/STARTERS.md
@@ -10,17 +10,17 @@
 | `python main.py` | 直接运行命令行版本游戏 |
 | `python main_enhanced.py` | 含 2.0 功能的增强版，生成 `game_log.html` |
  
-| `python run_web_ui.py` | 启动实验性的 Web 界面 |
-| `python run_web_ui.py` | 使用数据驱动引擎的 Web 界面 |
+| `python entrypoints/run_web_ui_optimized.py` | 启动实验性的 Web 界面 |
+| `python entrypoints/run_web_ui_optimized.py` | 使用数据驱动引擎的 Web 界面 |
  
-| `python run_web_ui.py` | 启动增强版 Web UI（推荐） |
-| `python run_web_ui.py` | 直接运行增强版 Web UI，跳过修复步骤 |
+| `python entrypoints/run_web_ui_optimized.py` | 启动增强版 Web UI（推荐） |
+| `python entrypoints/run_web_ui_optimized.py` | 直接运行增强版 Web UI，跳过修复步骤 |
  
 | `python archive/deprecated/run_web_ui_enhanced.py` | 启动旧版增强 Web UI（归档） |
 | `python archive/deprecated/run_web_ui_enhanced.py` | 直接运行旧版增强 Web UI，跳过修复步骤 |
  
  
-| `python run_web_ui.py` | 启动实验性的 Web 界面，使用数据驱动引擎 |
+| `python entrypoints/run_web_ui_optimized.py` | 启动实验性的 Web 界面，使用数据驱动引擎 |
 | `python run_web_ui_enhanced.py` | 启动增强版 Web UI（推荐，可跳过修复步骤） |
  
 | `python scripts/play_demo.py` | 带使用提示的演示版本 |

--- a/docs/complete_guide_v2.md
+++ b/docs/complete_guide_v2.md
@@ -28,7 +28,7 @@ pip install flask markdown
 ### 3. 启动游戏
 
 ```bash
-python run_web_ui_optimized.py
+python entrypoints/run_web_ui_optimized.py
 ```
 
 访问：http://localhost:5001

--- a/docs/development/FIX_NOTES.md
+++ b/docs/development/FIX_NOTES.md
@@ -13,10 +13,10 @@
 ### 3. 缺失的数据文件
 已创建以下必要的数据文件：
 - NPC对话数据 (`xwe/data/npc/dialogues.json`)
-- 角色模板 (`xwe/data/templates/character.json`)
-- NPC模板 (`xwe/data/templates/npc.json`)
-- 技能模板 (`xwe/data/templates/skill.json`)
-- 物品模板 (`xwe/data/templates/item.json`)
+- 角色模板 (`xwe/data/restructured/character.json`)
+- NPC模板 (`xwe/data/restructured/npc.json`)
+- 技能模板 (`xwe/data/restructured/skill.json`)
+- 物品模板 (`xwe/data/restructured/item.json`)
 - 武技数据 (`xwe/data/skills/martial_arts.json`)
 - 法术数据 (`xwe/data/skills/spells.json`)
 - 被动技能数据 (`xwe/data/skills/passive_skills.json`)

--- a/docs/lore_system_guide.md
+++ b/docs/lore_system_guide.md
@@ -104,7 +104,7 @@ RollSystem.randomAll()
 ### 1. 注册蓝图
 
 ```python
-# run_web_ui_optimized.py
+# entrypoints/run_web_ui_optimized.py
 from routes import lore, character
 
 app.register_blueprint(lore.bp)

--- a/docs/v2_implementation_summary.md
+++ b/docs/v2_implementation_summary.md
@@ -149,7 +149,7 @@ xianxia_world_engine/
 python test_v2_system.py
 
 # 或直接运行
-python run_web_ui_optimized.py
+python entrypoints/run_web_ui_optimized.py
 ```
 
 ### 添加背景音乐


### PR DESCRIPTION
## Summary
- mention `auto_archive.py` for clearing backups
- note `xwe/data/restructured/` as the unified template directory
- show `entrypoints/run_web_ui_optimized.py` in starter examples and guides

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684f7233ed9c8328a5d31e8911a2b7d5