### PR TITLE
更新快速启动文档并添加开发脚本

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,10 @@ python scripts/init_features.py
 - 服务层接口统一由 `xwe.services` 导出，可直接 `from xwe.services import IGameService`
 
 ### 运行测试
+在执行下列测试命令之前，请先安装依赖：
+```bash
+pip install -r requirements.txt
+```
 ```bash
 # 运行所有测试（默认使用 mock 模式）
 export LLM_PROVIDER=mock

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -36,6 +36,13 @@ python main_v3.py
 python run_enhanced_v3.py
 ```
 
+### 4. 运行测试
+在开始测试前，请安装依赖：
+```bash
+pip install -r requirements.txt
+pytest tests/ -v
+```
+
 ## 📚 核心概念速览
 
 ### 表达式系统

--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# 开发环境快速安装脚本
+set -e
+
+echo "安装依赖..."
+pip install -r requirements.txt
+
+echo "依赖安装完成"


### PR DESCRIPTION
## Summary
- 在 README 的测试部分加入依赖安装说明
- 在 `docs/QUICKSTART.md` 中新增“运行测试”小节，强调先安装依赖再执行 pytest
- 新增 `scripts/dev_setup.sh` 脚本，便于快速安装依赖

## Testing
- `pytest tests/ -v` *(fails: IndentationError in game_core_enhanced.py)*

------
https://chatgpt.com/codex/tasks/task_e_684f72354e4c8328b44419c674cb62f5