### PR TITLE
Remove sys.path fallbacks and clarify dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,6 @@ pytest >= 7.0.0  # 运行单元测试
 black >= 22.0.0  # 代码格式化
 mypy >= 1.0.0    # 类型检查
 pyyaml >= 6.0    # 用于YAML格式MOD支持
-python-dotenv>=1.0.0
+python-dotenv>=1.0.0  # 用于加载 .env 配置
 flask-swagger-ui>=4.12.0
 

--- a/xwe/core/nlp/__init__.py
+++ b/xwe/core/nlp/__init__.py
@@ -8,7 +8,7 @@ load_dotenv()
 提供自然语言理解和命令转换功能。
 """
 
-from xwe.core.nlp_processor import NLPProcessor, NLPConfig
-from xwe.core.llm_client import LLMClient
+from xwe.core.nlp.nlp_processor import NLPProcessor, NLPConfig
+from xwe.core.nlp.llm_client import LLMClient
 
 __all__ = ['NLPProcessor', 'NLPConfig', 'LLMClient']

--- a/xwe/utils/dotenv_helper.py
+++ b/xwe/utils/dotenv_helper.py
@@ -1,28 +1,11 @@
-from typing import Any, Optional
+from typing import Optional
 
 def load_dotenv(dotenv_path: Optional[str] = None) -> None:
-    """Load environment variables from a .env file.
-
-    Tries to use `python-dotenv`. If not installed, falls back to dotenv_backup or archive fallback.
-    """
+    """Load environment variables from a .env file using ``python-dotenv``."""
     try:
         from dotenv import load_dotenv as _load
-    except ImportError:
-        try:
-            from dotenv_backup import load_dotenv as _load  # type: ignore
-        except ImportError:
-            import sys
-            from pathlib import Path
-
-            # 尝试从项目的 _archive 目录中加载备用模块
-            backup_dir = Path(__file__).resolve().parent.parent.parent / "_archive"
-            sys.path.append(str(backup_dir))
-            try:
-                from dotenv_backup import load_dotenv as _load  # type: ignore
-            except ImportError:
-                raise ImportError(
-                    "Cannot find 'python-dotenv' or 'dotenv_backup'. "
-                    "Please install 'python-dotenv' using:\n"
-                    "pip install python-dotenv"
-                )
+    except ImportError as exc:
+        raise RuntimeError(
+            "The 'python-dotenv' package must be installed to load '.env' files."
+        ) from exc
     _load(dotenv_path)


### PR DESCRIPTION
## Summary
- clean up `load_dotenv` to require `python-dotenv`
- fix imports in `xwe.core.nlp`
- document the `python-dotenv` dependency in `requirements.txt`

## Testing
- `pytest tests/ -v` *(fails: ModuleNotFoundError: No module named 'xwe.core.character_roller')*

------
https://chatgpt.com/codex/tasks/task_e_684f813ddbf0832897cf4d909bc307dc