### PR TITLE
Fix Web UI optimized entrypoint

### DIFF
--- a/entrypoints/run_web_ui_optimized.py
+++ b/entrypoints/run_web_ui_optimized.py
@@ -272,7 +272,14 @@ def load_game():
     except Exception as e:
         return jsonify({'success': False, 'error': str(e)})
 
+if __name__ == '__main__':
     print("=== 修仙世界引擎 Web UI (优化版) ===")
     print("访问 http://localhost:5001 开始游戏")
     print("使用 Ctrl+C 停止服务器")
     print("=====================================")
+
+    # 确保存档目录存在
+    os.makedirs('saves', exist_ok=True)
+
+    # 启动服务器
+    app.run(debug=True, host='0.0.0.0', port=5001)

--- a/routes/intel.py
+++ b/routes/intel.py
@@ -3,7 +3,6 @@
 from flask import Blueprint, jsonify, session
 
 from xwe.features.intelligence_system import intelligence_system
-from entrypoints import run_web_ui_optimized
 
 bp = Blueprint("intel", __name__)
 
@@ -14,6 +13,8 @@ def get_intel():
     if 'session_id' not in session:
         return jsonify({'global': [], 'personal': []})
 
+    # 避免循环引用，在需要时再导入主应用模块
+    from entrypoints import run_web_ui_optimized
     instance = run_web_ui_optimized.get_game_instance(session['session_id'])
     game = instance['game']
     player_id = getattr(game.game_state.player, 'id', 'player') if game.game_state.player else 'player'


### PR DESCRIPTION
## Summary
- avoid circular import in `routes/intel.py`
- restore Flask server startup code in `entrypoints/run_web_ui_optimized.py`

## Testing
- `pytest tests/ -v` *(fails: AttributeError: 'PlayerData' object has no attribute 'experience_to_next')*
- `PYTHONPATH=. python entrypoints/run_web_ui_optimized.py` *(runs Flask server)*

------
https://chatgpt.com/codex/tasks/task_e_684fd635b3148328a82df5a29d92ad5c