### PR TITLE
Fix player API field names

### DIFF
--- a/api/v1/player.py
+++ b/api/v1/player.py
@@ -41,7 +41,7 @@ def get_player_info():
         'id': player.id,
         'name': player.name,
         'level': player.level,
-        'realm': player.cultivation_realm,
+        'realm': player.realm,
         'attributes': {
             'health': player.health,
             'max_health': player.max_health,
@@ -53,7 +53,7 @@ def get_player_info():
         },
         'stats': {
             'experience': player.experience,
-            'experience_to_next': player.experience_to_next_level,
+            'experience_to_next': player.experience_to_next,
             'spiritual_root': player.spiritual_root,
             'talent': player.talent,
             'fate': player.fate


### PR DESCRIPTION
## Summary
- correct property names in `api/v1/player.py`
- ensure tests pass

## Testing
- `pytest tests/unit/test_world_map_info.py -q`
- `pytest tests -q`

------
https://chatgpt.com/codex/tasks/task_e_68503bf81acc83289604b271e9a8335d