### PR TITLE
Add spirit_stone alias support

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,9 @@ pip install -r requirements.txt
 pytest tests/
 ```
 
+> **注意**：物品ID建议统一使用複数形式，例如 `spirit_stones`，旧写法
+> `spirit_stone` 仍被兼容。
+
 ### 创建自定义游戏
 ```python
 from xwe.core.orchestrator import GameConfig, GameOrchestrator

--- a/xwe/core/item_system.py
+++ b/xwe/core/item_system.py
@@ -1,5 +1,7 @@
 """
 物品系统 - 管理游戏中的物品、背包、交易等
+
+统一使用 ``spirit_stones`` 作为灵石的物品ID，兼容旧写法 ``spirit_stone``。
 """
 
 from typing import Any, Dict, List, Optional
@@ -19,27 +21,39 @@ class Item:
 
 class ItemSystem:
     """物品系统管理器"""
-    
+
     def __init__(self) -> None:
         self.items: Dict[str, Item] = {}
         self.player_inventories: Dict[str, Dict[str, int]] = {}
-    
+        # 物品ID别名映射，便于兼容历史写法
+        self.item_id_aliases = {
+            'spirit_stone': 'spirit_stones',
+            'spirit_stones': 'spirit_stones',
+        }
+
+    def _resolve_item_id(self, item_id: str) -> str:
+        """根据别名获取统一的物品ID"""
+        return self.item_id_aliases.get(item_id, item_id)
+
     def get_spirit_stones(self, player_id: str) -> int:
         """获取玩家的灵石数量"""
         inventory = self.player_inventories.get(player_id, {})
-        return inventory.get('spirit_stones', 0)
-    
+        # 兼容早期存档中的 "spirit_stone" 字段
+        return inventory.get('spirit_stones', 0) + inventory.get('spirit_stone', 0)
+
     def add_item(self, player_id: str, item_id: str, quantity: int = 1) -> bool:
         """添加物品到玩家背包"""
+        item_id = self._resolve_item_id(item_id)
         if player_id not in self.player_inventories:
             self.player_inventories[player_id] = {}
-        
+
         current = self.player_inventories[player_id].get(item_id, 0)
         self.player_inventories[player_id][item_id] = current + quantity
         return True
-    
+
     def remove_item(self, player_id: str, item_id: str, quantity: int = 1) -> bool:
         """从玩家背包移除物品"""
+        item_id = self._resolve_item_id(item_id)
         inventory = self.player_inventories.get(player_id, {})
         if inventory.get(item_id, 0) >= quantity:
             inventory[item_id] -= quantity


### PR DESCRIPTION
## Summary
- support `spirit_stone` alias for `spirit_stones`
- document unified item ID in README

## Testing
- `pytest tests/unit/test_optimizations.py::test_item_system -q`
- `pytest tests/ -v` *(fails: test_service_container, test_system_manager)*

------
https://chatgpt.com/codex/tasks/task_e_685130b6dc308328a4646d7fddef4c92