### PR TITLE
Allow alias 'c' in service container

### DIFF
--- a/xwe/core/services/container.py
+++ b/xwe/core/services/container.py
@@ -154,8 +154,8 @@ class ServiceContainer:
             if param_name == 'self':
                 continue
                 
-            # 特殊处理：如果参数名是 'container'，注入容器本身
-            if param_name == 'container':
+            # 特殊处理：如果参数名是 'container' 或常见别名，则注入容器本身
+            if param_name in ('container', 'c'):
                 kwargs[param_name] = self
                 continue
                 


### PR DESCRIPTION
## Summary
- allow container injection for the alias `c` in `_create_with_dependencies`
- keep backward compatibility

## Testing
- `pytest tests/test_infrastructure.py::test_service_container -q`

------
https://chatgpt.com/codex/tasks/task_e_685130b544448328a78ac06a1166b3ed