### PR TITLE
Fix GameState duplicates and adjust injection

### DIFF
--- a/tests/unit/test_optimizations.py
+++ b/tests/unit/test_optimizations.py
@@ -11,10 +11,12 @@ def test_imports():
     print("🔍 测试模块导入...")
     
     try:
+        from xwe.core.system_manager import system_manager
         # 测试新创建的系统模块
         from xwe.core.item_system import item_system, Item, ItemSystem
         print("✅ item_system 导入成功")
         
+        from xwe.core.system_manager import system_manager, SystemManager
         print("✅ system_manager 导入成功")
         
         from xwe.core.confirmation_manager import confirmation_manager, ConfirmationManager
@@ -88,9 +90,10 @@ def test_item_system():
 def test_system_manager():
     """测试系统管理器功能"""
     print("\n⚙️ 测试系统管理器...")
-    
+
     try:
-        
+        from xwe.core.system_manager import system_manager
+
         # 测试修炼系统激活
         test_system = {
             'name': '九转修炼系统',

--- a/xwe/core/game_core.py
+++ b/xwe/core/game_core.py
@@ -47,12 +47,10 @@ class GameState:
 
     game_time: float = 0.0  # 游戏时间（小时）
     active_hours: float = 0.0  # 连续活动时长
-    game_time: int = 0  # 游戏时间（回合数）
     game_mode: str = "player"  # 游戏模式：player 或 dev
 
     flags: Dict[str, Any] = field(default_factory=dict)
     npcs: Dict[str, Character] = field(default_factory=dict)
-    game_mode: str = "player"
     
     def to_dict(self) -> Dict[str, Any]:
         """转换为可序列化的字典"""
@@ -61,14 +59,10 @@ class GameState:
             'current_location': self.current_location,
             'current_combat': self.current_combat,
             'game_time': self.game_time,
-
             'active_hours': self.active_hours,
-
             'game_mode': self.game_mode,
-
             'flags': self.flags,
             'npcs': {npc_id: npc.to_dict() for npc_id, npc in self.npcs.items()},
-            'game_mode': self.game_mode
         }
     
     @classmethod
@@ -84,15 +78,11 @@ class GameState:
 
         state.game_time = data.get('game_time', 0.0)
         state.active_hours = data.get('active_hours', 0.0)
-
-        state.game_time = data.get('game_time', 0)
         state.game_mode = data.get('game_mode', 'player')
 
         state.flags = data.get('flags', {})
         if 'npcs' in data:
             state.npcs = {nid: Character.from_dict(nc) for nid, nc in data['npcs'].items()}
-
-        state.game_mode = data.get('game_mode', 'player')
 
         return state
 

--- a/xwe/core/item_system.py
+++ b/xwe/core/item_system.py
@@ -27,7 +27,8 @@ class ItemSystem:
     def get_spirit_stones(self, player_id: str) -> int:
         """获取玩家的灵石数量"""
         inventory = self.player_inventories.get(player_id, {})
-        return inventory.get('spirit_stones', 0)
+        # 兼容不同写法的灵石ID
+        return inventory.get('spirit_stone', inventory.get('spirit_stones', 0))
     
     def add_item(self, player_id: str, item_id: str, quantity: int = 1) -> bool:
         """添加物品到玩家背包"""

--- a/xwe/core/services/container.py
+++ b/xwe/core/services/container.py
@@ -154,8 +154,8 @@ class ServiceContainer:
             if param_name == 'self':
                 continue
                 
-            # 特殊处理：如果参数名是 'container'，注入容器本身
-            if param_name == 'container':
+            # 特殊处理：如果参数名是 'container' 或縮寫 'c'，注入容器本身
+            if param_name in {'container', 'c'}:
                 kwargs[param_name] = self
                 continue
                 


### PR DESCRIPTION
## Summary
- deduplicate `game_time` and `game_mode` fields in `GameState`
- update serialization helpers to match new fields
- allow `ServiceContainer` to inject `c` as an alias for the container
- make `ItemSystem.get_spirit_stones` accept both `spirit_stone` and `spirit_stones`
- fix test utilities to import `system_manager`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685130b389348328a189ee65b3e8dc6d