### PR TITLE
Fix ruff warnings in selected files

### DIFF
--- a/xwe/features/visual_enhancement.py
+++ b/xwe/features/visual_enhancement.py
@@ -7,9 +7,7 @@
 
 import time
 import sys
-import random
-from typing import Any, Callable, Dict, List, Optional
-from enum import Enum
+from typing import List, Optional
 
 class Color:
     """ANSI颜色代码"""

--- a/xwe/metrics/prometheus.py
+++ b/xwe/metrics/prometheus.py
@@ -5,11 +5,10 @@ Prometheus指标导出器
 
 import time
 import threading
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Dict, List, Optional
 from dataclasses import dataclass, field
 from enum import Enum
 from collections import defaultdict
-import json
 
 
 class MetricType(Enum):
@@ -133,7 +132,7 @@ class PrometheusMetrics:
                 raise ValueError(f"Metric {name} is not a counter")
                 
             if labels:
-                label_values = tuple(labels.get(l, "") for l in self._metrics[name].labels)
+                label_values = tuple(labels.get(label, "") for label in self._metrics[name].labels)
                 
                 # 检查标签基数
                 if label_values not in self._labels_values[name]:
@@ -157,7 +156,7 @@ class PrometheusMetrics:
                 raise ValueError(f"Metric {name} is not a gauge")
                 
             if labels:
-                label_values = tuple(labels.get(l, "") for l in self._metrics[name].labels)
+                label_values = tuple(labels.get(label, "") for label in self._metrics[name].labels)
                 self._labels_values[name][label_values] = value
             else:
                 self._values[name] = value
@@ -172,7 +171,7 @@ class PrometheusMetrics:
                 raise ValueError(f"Metric {name} is not a histogram")
                 
             if labels:
-                label_values = tuple(labels.get(l, "") for l in self._metrics[name].labels)
+                label_values = tuple(labels.get(label, "") for label in self._metrics[name].labels)
                 key = f"{name}:{label_values}"
             else:
                 key = name

--- a/xwe/npc/enhanced_dialogue.py
+++ b/xwe/npc/enhanced_dialogue.py
@@ -9,11 +9,10 @@ import logging
 from typing import Any, Dict, List, Optional, Tuple
 from dataclasses import dataclass, field
 import random
-import re
 
-from .dialogue_system import DialogueSystem, DialogueNode, DialogueTree, DialogueNodeType
+from .dialogue_system import DialogueSystem, DialogueNode, DialogueNodeType
 from .emotion_system import EmotionSystem, EmotionType
-from .memory_system import MemorySystem, MemoryType
+from .memory_system import MemorySystem
 from ..core.nlp.nlp_processor import NLPProcessor
 
 logger = logging.getLogger(__name__)
@@ -154,7 +153,6 @@ class DialogueGenerator:
                          intent: Optional[str] = None) -> str:
         """生成响应"""
         # 基于情感状态调整语气
-        emotion_factor = context.emotion_intensity
         relationship_factor = (context.relationship + 100) / 200  # 归一化到0-1
         
         # 识别话题
@@ -341,14 +339,13 @@ class EnhancedDialogueSystem:
         
         # 使用NLP理解意图
         intent = None
-        entities: Dict[str, Any] = {}
         
         if self.nlp_processor:
             try:
                 nlp_result = self.nlp_processor.parse(input_text)
                 intent = nlp_result.get("intent")
-                entities = nlp_result.get("entities", {})
-            except:
+                _ = nlp_result.get("entities", {})
+            except Exception:
                 logger.warning("NLP处理失败，使用关键词匹配")
         
         # 如果没有NLP或处理失败，使用简单的关键词匹配

--- a/xwe/tests/test_output_manager.py
+++ b/xwe/tests/test_output_manager.py
@@ -9,8 +9,7 @@ import tempfile
 from pathlib import Path
 from datetime import datetime
 from queue import Queue
-import time
-from unittest.mock import Mock, patch, MagicMock
+from unittest.mock import Mock, patch
 
 from xwe.core.output import (
     OutputManager,
@@ -544,8 +543,6 @@ class TestOutputManager:
         mock_channel = Mock(spec=ConsoleChannel)
         mock_channel.name = "test"
         manager.add_channel(mock_channel)
-        
-        outputs = []
         
         def output_messages(start, count):
             for i in range(count):

--- a/xwe/world/location_manager.py
+++ b/xwe/world/location_manager.py
@@ -10,7 +10,7 @@ from typing import Any, Dict, List, Optional, Set, Tuple
 from dataclasses import dataclass, field
 import random
 
-from .world_map import WorldMap, Area, AreaType
+from .world_map import WorldMap, AreaType
 
 logger = logging.getLogger(__name__)
 
@@ -344,6 +344,6 @@ class LocationManager:
                 if connected.is_discovered:
                     description += f"\n- {connected.name} ({connected.type.value})"
                 else:
-                    description += f"\n- 未知区域"
+                    description += "\n- 未知区域"
         
         return description


### PR DESCRIPTION
## Summary
- clean up imports in `visual_enhancement`
- rename loop variables in prometheus metrics
- drop unused variables and fix bare except in enhanced dialogue
- fix f-string and unused import in location manager
- remove unused imports and variable in tests

## Testing
- `ruff check xwe/features/visual_enhancement.py xwe/metrics/prometheus.py xwe/npc/enhanced_dialogue.py xwe/world/location_manager.py xwe/tests/test_output_manager.py`
- `pytest tests/ -v` *(fails: IndentationError in services container)*

------
https://chatgpt.com/codex/tasks/task_e_6853d2719d0883288f972e0823523b12