### PR TITLE
Clarify container alias comment

### DIFF
--- a/xwe/core/services/container.py
+++ b/xwe/core/services/container.py
@@ -154,11 +154,7 @@ class ServiceContainer:
             if param_name == 'self':
                 continue
 
-               
-            # 特殊处理：如果参数名是 'container' 或縮寫 'c'，注入容器本身
-
-
-            # 特殊处理：如果参数名是 'container' 或常见别名，则注入容器本身
+            # 特殊处理：如果参数名是 'container' 或简称 'c'，则注入容器本身
             if param_name in ('container', 'c'):
 
                 kwargs[param_name] = self


### PR DESCRIPTION
## Summary
- clarify container alias comment in ServiceContainer

## Testing
- `pytest tests/ -v` *(fails: Directory domain does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68540e0f0e84832890757bb2778909f7