### PR TITLE
Fix dev blueprint registration

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -53,7 +53,10 @@ def register_api(app: Flask, url_prefix: str = "/api"):
         from xwe.config import config
 
         if config.ENABLE_DEV_API:
-            app.register_blueprint(dev_bp, url_prefix=f"{v1_prefix}/dev")
+            if dev_bp is not None:
+                app.register_blueprint(dev_bp, url_prefix=f"{v1_prefix}/dev")
+            else:
+                print("⚠️  dev_bp is None, skipping dev API registration")
     except Exception:
         pass
 


### PR DESCRIPTION
## Summary
- skip registering dev API when blueprint isn't defined

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6856a338c1a083289c759c13072aa1a2