### PR TITLE
移除logging依赖

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,5 @@ aiofiles==23.1.0
 psutil==5.9.5
 
 # 日志
-logging==0.4.9.6
-
 # 其他工具
 requests==2.31.0


### PR DESCRIPTION
## 总结
- 删除 `requirements.txt` 中的 `logging==0.4.9.6` 条目

## 测试
- `pip install -r requirements.txt`


------
https://chatgpt.com/codex/tasks/task_e_6856a379f160832888db704c5f4318cb