### PR TITLE
Implement missing API v1 logic

### DIFF
--- a/api/v1/player.py
+++ b/api/v1/player.py
@@ -3,7 +3,10 @@
 处理玩家角色的创建、查询和更新
 """
 
-from flask import Blueprint, jsonify, request
+from flask import Blueprint, jsonify, request, session
+import time
+from xwe.core.character import Character, CharacterType
+from xwe.core.attributes import CharacterAttributes
 
 player_bp = Blueprint('player', __name__)
 
@@ -11,20 +14,19 @@ player_bp = Blueprint('player', __name__)
 @player_bp.route('/info', methods=['GET'])
 def get_player_info():
     """获取玩家信息"""
-    # TODO: 从会话中获取玩家信息
-    return jsonify({
-        "id": "player_001",
-        "name": "无名侠客",
-        "level": 1,
-        "realm": "炼气期",
-        "attributes": {
-            "health": 100,
-            "mana": 50,
-            "stamina": 100,
-            "attack": 10,
-            "defense": 5
-        }
-    })
+    if 'session_id' not in session:
+        return jsonify({"error": "会话已过期"}), 401
+
+    from entrypoints import run_web_ui_optimized
+
+    instance = run_web_ui_optimized.get_game_instance(session['session_id'])
+    game = instance["game"]
+    player = game.game_state.player
+
+    if not player:
+        return jsonify({"error": "未找到玩家"}), 404
+
+    return jsonify(player.to_dict())
 
 
 @player_bp.route('/create', methods=['POST'])
@@ -33,43 +35,69 @@ def create_player():
     data = request.get_json()
     name = data.get('name', '无名侠客')
     character_type = data.get('type', 'balanced')
-    
-    # TODO: 实现角色创建逻辑
-    return jsonify({
-        "success": True,
-        "player": {
-            "id": "player_new",
-            "name": name,
-            "type": character_type
-        }
-    })
+
+    if 'session_id' not in session:
+        session['session_id'] = str(time.time())
+
+    from entrypoints import run_web_ui_optimized
+
+    instance = run_web_ui_optimized.get_game_instance(session['session_id'])
+    game = instance["game"]
+
+    attrs = CharacterAttributes()
+    player = Character(id="player", name=name, character_type=CharacterType.PLAYER, attributes=attrs)
+
+    if character_type == 'sword':
+        player.attributes.attack_power += 5
+    elif character_type == 'body':
+        player.attributes.defense += 5
+    elif character_type == 'magic':
+        player.attributes.max_mana += 20
+
+    game.game_state.player = player
+    instance["need_refresh"] = True
+
+    return jsonify({"success": True, "player": player.to_dict()})
 
 
 @player_bp.route('/inventory', methods=['GET'])
 def get_inventory():
     """获取玩家背包"""
-    # TODO: 实现背包系统
-    return jsonify({
-        "items": [],
-        "capacity": 50,
-        "used": 0
-    })
+    if 'session_id' not in session:
+        return jsonify({"items": [], "capacity": 0, "used": 0})
+
+    from entrypoints import run_web_ui_optimized
+
+    instance = run_web_ui_optimized.get_game_instance(session['session_id'])
+    game = instance["game"]
+    player = game.game_state.player
+
+    if not player:
+        return jsonify({"items": [], "capacity": 0, "used": 0})
+
+    inventory = player.inventory.to_dict()
+    inventory["used"] = len(player.inventory.items)
+    return jsonify(inventory)
 
 
 @player_bp.route('/skills', methods=['GET'])
 def get_skills():
     """获取玩家技能"""
-    # TODO: 实现技能系统
-    return jsonify({
-        "skills": [
-            {
-                "id": "basic_attack",
-                "name": "基础攻击",
-                "level": 1,
-                "cooldown": 0
-            }
-        ]
-    })
+    if 'session_id' not in session:
+        return jsonify({"skills": []})
+
+    from entrypoints import run_web_ui_optimized
+
+    instance = run_web_ui_optimized.get_game_instance(session['session_id'])
+    game = instance["game"]
+    player = game.game_state.player
+
+    skills = []
+    if player:
+        for skill_id in getattr(player, 'skills', []):
+            skills.append({"id": skill_id})
+
+    return jsonify({"skills": skills})
 
 
 @player_bp.route('/cultivate', methods=['POST'])
@@ -77,10 +105,27 @@ def cultivate():
     """修炼"""
     data = request.get_json()
     duration = data.get('duration', 1)
-    
-    # TODO: 实现修炼系统
+    if 'session_id' not in session:
+        return jsonify({"success": False, "error": "会话已过期"}), 401
+
+    from entrypoints import run_web_ui_optimized
+
+    instance = run_web_ui_optimized.get_game_instance(session['session_id'])
+    game = instance["game"]
+    player = game.game_state.player
+
+    if not player:
+        return jsonify({"success": False, "error": "未找到玩家"}), 404
+
+    exp_gained = 0
+    if hasattr(game, 'cultivation_system'):
+        exp_gained = game.cultivation_system.calculate_cultivation_exp(player, duration)
+        player.attributes.cultivation_exp += exp_gained
+
+    instance["need_refresh"] = True
+
     return jsonify({
         "success": True,
-        "exp_gained": duration * 10,
+        "exp_gained": exp_gained,
         "message": f"修炼了{duration}个时辰"
     })


### PR DESCRIPTION
## Summary
- flesh out game API endpoints to use the active session and game instance
- expose player details, inventory and skills from the current session
- implement saving/loading of `GameState`
- add system settings persistence, log retrieval and performance metrics

## Testing
- `python -m py_compile api/v1/game.py api/v1/player.py api/v1/save.py api/v1/system.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856a6cc4dc08328b7c8ef18047a5219