### PR TITLE
Add basic pytest suite

### DIFF
--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -13,3 +13,10 @@
 ## 启动方式
 1. 控制台: python main_menu.py
 2. Web: python entrypoints/run_web_ui_optimized.py
+
+## 测试
+使用 [pytest](https://docs.pytest.org/) 运行单元测试：
+
+```bash
+pytest
+```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,30 @@
+import pytest
+from flask import Flask
+import importlib.util
+from pathlib import Path
+import werkzeug
+
+if not hasattr(werkzeug, "__version__"):
+    werkzeug.__version__ = "0"
+
+def _load_module(path, name):
+    spec = importlib.util.spec_from_file_location(name, Path(path))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore
+    return module
+
+game_bp = _load_module('api/v1/game.py', 'game').game_bp
+system_bp = _load_module('api/v1/system.py', 'system').system_bp
+
+@pytest.fixture
+def app():
+    app = Flask(__name__)
+    app.secret_key = "test_secret"
+    app.register_blueprint(game_bp, url_prefix='/api/v1/game')
+    app.register_blueprint(system_bp, url_prefix='/api/v1/system')
+    app.config.update(TESTING=True)
+    return app
+
+@pytest.fixture
+def client(app):
+    return app.test_client()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,13 @@
+def test_system_info(client):
+    resp = client.get('/api/v1/system/info')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data.get('version') == '1.0.0'
+    assert 'features' in data
+
+
+def test_game_status_without_session(client):
+    resp = client.get('/api/v1/game/status')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data.get('status') == 'idle'

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,0 +1,30 @@
+import importlib.util
+from pathlib import Path
+import sys
+import types
+
+def _load_module(path, name):
+    spec = importlib.util.spec_from_file_location(name, Path(path))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore
+    return module
+
+CommandRouter = _load_module('xwe/core/command_router.py', 'command_router').CommandRouter
+Inventory = _load_module('xwe/core/inventory.py', 'inventory').Inventory
+
+
+def test_command_router_move():
+    router = CommandRouter()
+    cmd, params = router.route_command('移动 北')
+    assert cmd == 'move'
+    assert params.get('target') == '北'
+
+
+def test_inventory_add_remove():
+    inv = Inventory(capacity=2)
+    assert inv.add('sword')
+    assert inv.add('potion', 2)
+    assert inv.is_full()
+    assert inv.get_quantity('potion') == 2
+    assert inv.remove('potion')
+    assert inv.get_quantity('potion') == 1

--- a/xwe/core/__init__.py
+++ b/xwe/core/__init__.py
@@ -8,10 +8,9 @@ from typing import Any, Dict
 from xwe.core.ai import AIController
 from xwe.core.attributes import AttributeSystem, CharacterAttributes
 from xwe.core.character import Character
-from xwe.core.combat import CombatSystem, combat_system
+from xwe.core.combat import CombatSystem
 from xwe.core.command_parser import CommandParser
 from xwe.core.data_loader import DataLoader
-from xwe.core.event_system import EventSystemV3 as EventSystem
 from xwe.core.game_core import GameCore
 from xwe.core.skills import Skill, SkillSystem
 from xwe.core.status import StatusEffect, StatusEffectManager
@@ -73,12 +72,10 @@ __all__ = [
     "StatusEffectManager",
     "CommandParser",
     "GameCore",
-    "EventSystem",
     "load_game_data",
     "get_config",
     "calculate",
     "evaluate_expression",
-    "combat_system",
 ] + list(
     _optional_modules.keys()
 )  # 动态添加可选模块

--- a/xwe/utils/dotenv_helper.py
+++ b/xwe/utils/dotenv_helper.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+from dotenv import load_dotenv as _load_dotenv
+
+
+def load_dotenv(path: str | None = None) -> None:
+    """Load environment variables from a .env file if it exists."""
+    env_path = Path(path or '.env')
+    if env_path.exists():
+        _load_dotenv(env_path)


### PR DESCRIPTION
## Summary
- add placeholder dotenv helper
- fix imports in `xwe.core.__init__`
- document how to run tests
- create minimal pytest suite for API and core modules

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856a6cdc1208328b2fd53dbbfaa8aec