### PR TITLE
Handle dev blueprint based on FLASK_ENV

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -5,11 +5,16 @@ OpenAPI 文档生成器
 
 from flask import Flask, jsonify
 from flask_swagger_ui import get_swaggerui_blueprint
+import os
 
 from .middleware import register_middleware
 from .specs.openapi_generator import setup_swagger_ui as setup_openapi_ui
 from .v1 import game_bp, player_bp, save_bp, system_bp
-from .v1.dev import dev_bp
+
+if os.getenv("FLASK_ENV") == "development":
+    from .v1.dev import dev_bp
+else:
+    dev_bp = None
 
 # OpenAPI 规范主体结构
 openapi_spec = {

--- a/api/v1/dev/__init__.py
+++ b/api/v1/dev/__init__.py
@@ -3,6 +3,12 @@
 提供调试和测试功能
 """
 
-from .dev_routes import dev_bp
+"""根据当前环境决定是否导出开发蓝图"""
+
+import os
+
+from .dev_routes import dev_bp as _dev_bp
+
+dev_bp = _dev_bp if os.getenv("FLASK_ENV") == "development" else None
 
 __all__ = ["dev_bp"]

--- a/api/v1/dev/dev_routes.py
+++ b/api/v1/dev/dev_routes.py
@@ -6,11 +6,8 @@
 from flask import Blueprint, jsonify, request
 import os
 
+# 无论环境如何都先创建蓝图，随后再在外部判断是否导出
 dev_bp = Blueprint('dev', __name__)
-
-# 仅在开发模式下启用
-if os.getenv("FLASK_ENV") != "development":
-    dev_bp = None
 
 
 @dev_bp.route('/debug', methods=['GET'])


### PR DESCRIPTION
## Summary
- create dev blueprint unconditionally
- expose the blueprint only in development
- guard blueprint registration in `api/__init__.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68579e176f888328bf0771a79e7c1d34