### PR TITLE
Fix missing technical ops classes

### DIFF
--- a/xwe/features/technical_ops.py
+++ b/xwe/features/technical_ops.py
@@ -275,7 +275,7 @@ class TechnicalOps:
         # 这里简化处理，实际应该根据具体的游戏状态结构来反序列化
         # 可能需要导入GameState类并调用from_dict方法
         return data
-    
+
     def run_diagnostics(self) -> Dict[str, Any]:
         """运行诊断检查"""
         diagnostics = {
@@ -286,5 +286,63 @@ class TechnicalOps:
             "python_version": os.sys.version,
             "platform": os.sys.platform
         }
-        
+
         return diagnostics
+
+
+# ---------------------------------------------------------------------------
+# 以下类和函数目前尚未完整实现，仅提供占位实现以避免导入错误
+# ---------------------------------------------------------------------------
+
+
+class AutoBackupManager:
+    """AUTO-STUB：自动备份管理器"""
+
+    pass
+
+
+class ErrorHandler:
+    """AUTO-STUB：技术错误处理器"""
+
+    pass
+
+
+class ErrorLog:
+    """AUTO-STUB：错误日志记录"""
+
+    pass
+
+
+class PerformanceMonitor:
+    """AUTO-STUB：性能监控器"""
+
+    pass
+
+
+class SaveGame:
+    """AUTO-STUB：存档对象"""
+
+    pass
+
+
+class SaveManager:
+    """AUTO-STUB：存档管理器"""
+
+    pass
+
+
+class TechnicalOpsSystem:
+    """AUTO-STUB：技术运维系统入口"""
+
+    def __init__(self):
+        self.ops = TechnicalOps()
+
+
+tech_ops_system = TechnicalOpsSystem()
+
+
+def integrate_technical_features(game: Any) -> None:
+    """AUTO-STUB：将技术运维功能整合到游戏对象"""
+
+    game.tech_ops_system = tech_ops_system
+


### PR DESCRIPTION
## Summary
- add stub technical ops classes to avoid import errors
- wire them into `tech_ops_system` for now

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68579e0aa77883289f47f7f293e4cb91