### PR TITLE
Fix SkillSystem init call

### DIFF
--- a/xwe/core/game_core.py
+++ b/xwe/core/game_core.py
@@ -120,7 +120,7 @@ class GameCore:
         self.data_loader = DataLoader(data_path)
         self.parser = ExpressionParser()
         self.attribute_system = AttributeSystem(self.parser)
-        self.skill_system = SkillSystem(self.data_loader, self.parser)
+        self.skill_system = SkillSystem()
         self.combat_system = CombatSystem(self.skill_system, self.parser)
         self.ai_controller = AIController(self.skill_system)
         self.command_parser = CommandParser()


### PR DESCRIPTION
## Summary
- fix erroneous SkillSystem constructor usage

## Testing
- `pytest -q` *(fails: KeyboardInterrupt after 105s)*
- `python entrypoints/run_web_ui_optimized.py`

------
https://chatgpt.com/codex/tasks/task_e_6857b2bd9ef08328b782ad6a3e0af818