### PR TITLE
Add achievement system tests

### DIFF
--- a/tests/debug/__init__.py
+++ b/tests/debug/__init__.py
@@ -1,0 +1,1 @@
+# debug package

--- a/tests/debug/test_imports.py
+++ b/tests/debug/test_imports.py
@@ -6,6 +6,10 @@
 import sys
 import os
 from pathlib import Path
+import pytest
+if __name__ != "__main__":
+    pytest.skip("debug script", allow_module_level=True)
+
 
 # 添加项目根目录到路径
 PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent

--- a/tests/test_achievement_system.py
+++ b/tests/test_achievement_system.py
@@ -1,0 +1,59 @@
+import importlib.util
+from pathlib import Path
+
+
+def _load_module(path, name):
+    spec = importlib.util.spec_from_file_location(name, Path(path))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore
+    return module
+
+ach_module = _load_module('xwe/core/achievement_system.py', 'achievement_system')
+AchievementSystem = ach_module.AchievementSystem
+
+
+def test_invalid_achievement_id():
+    system = AchievementSystem()
+    assert not system.check_achievement('nonexistent')
+
+
+def test_claim_before_completion():
+    system = AchievementSystem()
+    assert system.claim_achievement_rewards('first_battle') is None
+
+
+def test_complete_and_claim():
+    system = AchievementSystem()
+    assert system.check_achievement('first_battle')
+    # Already completed, should return False
+    assert not system.check_achievement('first_battle')
+    rewards = system.claim_achievement_rewards('first_battle')
+    assert rewards == {'exp': 100, 'gold': 50}
+    # Duplicate claim should return None
+    assert system.claim_achievement_rewards('first_battle') is None
+
+
+def test_hidden_achievement_visibility():
+    system = AchievementSystem()
+    normal_list = [a['id'] for a in system.get_achievement_list()]
+    assert 'win_streak_10' not in normal_list
+    all_list = [a['id'] for a in system.get_achievement_list(show_hidden=True)]
+    assert 'win_streak_10' in all_list
+
+
+def test_unique_requirement_and_stats():
+    system = AchievementSystem()
+    # Requirement not met
+    assert not system.check_achievement('explorer_5', value=3)
+    assert not system.player_progress['explorer_5'].completed
+    # Complete achievement
+    assert system.check_achievement('explorer_5', value=5)
+    rewards = system.claim_achievement_rewards('explorer_5')
+    assert rewards == {'item': 'explorer_map'}
+    # Total points should include both first_battle and explorer_5 after completion
+    system.check_achievement('first_battle')
+    system.claim_achievement_rewards('first_battle')
+    assert system.get_total_points() == 25
+    stats = system.get_completion_stats()
+    assert stats['completed'] >= 2
+    assert stats['total_points'] == system.get_total_points()


### PR DESCRIPTION
## Summary
- add unit tests for achievement system covering edge cases
- prevent debug import script from running during pytest

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858a1a983b8832882727047932f3c65