### PR TITLE
Add unit and integration tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ from flask import Flask
 import importlib.util
 from pathlib import Path
 import werkzeug
+import os
 
 if not hasattr(werkzeug, "__version__"):
     werkzeug.__version__ = "0"
@@ -16,13 +17,24 @@ def _load_module(path, name):
 game_bp = _load_module('api/v1/game.py', 'game').game_bp
 system_bp = _load_module('api/v1/system.py', 'system').system_bp
 
+@pytest.fixture(autouse=True)
+def test_env(monkeypatch):
+    monkeypatch.setenv("FLASK_ENV", "testing")
+    monkeypatch.setenv("DEBUG", "false")
+    yield
+
+
 @pytest.fixture
-def app():
+def app(tmp_path):
     app = Flask(__name__)
     app.secret_key = "test_secret"
     app.register_blueprint(game_bp, url_prefix='/api/v1/game')
     app.register_blueprint(system_bp, url_prefix='/api/v1/system')
-    app.config.update(TESTING=True)
+    app.config.update(
+        TESTING=True,
+        VERSION="1.0.0",
+        LOG_PATH=str(tmp_path)
+    )
     return app
 
 @pytest.fixture

--- a/tests/test_api_integration.py
+++ b/tests/test_api_integration.py
@@ -1,0 +1,32 @@
+import json
+
+
+def test_get_settings(client):
+    resp = client.get('/api/v1/system/settings')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert 'graphics' in data
+    assert 'audio' in data
+
+
+def test_update_settings(client, tmp_path):
+    payload = {'graphics': {'text_speed': 'fast'}}
+    resp = client.put('/api/v1/system/settings', data=json.dumps(payload), content_type='application/json')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['success']
+
+
+def test_get_logs(client):
+    resp = client.get('/api/v1/system/logs')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert 'logs' in data
+    assert isinstance(data['logs'], list)
+
+
+def test_game_time_no_session(client):
+    resp = client.get('/api/v1/game/time')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['time_of_day'] == 'unknown'

--- a/tests/test_game_service.py
+++ b/tests/test_game_service.py
@@ -1,0 +1,69 @@
+import importlib.util
+from pathlib import Path
+import sys
+import types
+
+
+def _load_module(path, name):
+    spec = importlib.util.spec_from_file_location(name, Path(path))
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)  # type: ignore
+    return module
+
+
+stub_services = types.ModuleType('xwe.services')
+
+
+class StubServiceBase:
+    def __init__(self, container):
+        self.container = container
+        self._initialized = False
+        import logging
+        self.logger = logging.getLogger(self.__class__.__name__)
+
+    def __class_getitem__(cls, item):
+        return cls
+
+    def initialize(self):
+        self._initialized = True
+
+    def shutdown(self):
+        self._initialized = False
+
+
+class StubServiceContainer:
+    pass
+
+
+stub_services.ServiceBase = StubServiceBase
+stub_services.ServiceContainer = StubServiceContainer
+sys.modules['xwe.services'] = stub_services
+
+game_service_module = _load_module('xwe/services/game_service.py', 'xwe.services.game_service')
+GameService = game_service_module.GameService
+CommandResult = game_service_module.CommandResult
+
+
+class DummyContainer:
+    pass
+
+
+def test_process_command_success():
+    container = DummyContainer()
+    service = GameService(container)
+
+    result = service.process_command("look around")
+    assert isinstance(result, CommandResult)
+    assert result.success
+
+
+def test_initialize_and_shutdown():
+    container = DummyContainer()
+    service = GameService(container)
+
+    service.initialize()
+    assert service._initialized
+
+    service.shutdown()
+    assert not service._initialized

--- a/tests/test_narrative_system.py
+++ b/tests/test_narrative_system.py
@@ -1,0 +1,61 @@
+import pytest
+from xwe.features.narrative_system import (
+    NarrativeSystem,
+    StoryNode,
+    StoryPhase,
+)
+
+
+def create_simple_narrative_system():
+    ns = NarrativeSystem()
+    ns.story_arcs["test_arc"] = {}
+    ns.story_nodes["test_arc_start"] = StoryNode(
+        id="test_arc_start",
+        phase=StoryPhase.INTRODUCTION,
+        content="start",
+        choices=[{"text": "go", "next": "next_node"}]
+    )
+    ns.story_nodes["next_node"] = StoryNode(
+        id="next_node",
+        phase=StoryPhase.RISING_ACTION,
+        content="next"
+    )
+    return ns
+
+
+def test_start_story_arc_invalid():
+    ns = NarrativeSystem()
+    assert ns.start_story_arc("p1", "unknown") is None
+
+
+def test_story_flow():
+    ns = create_simple_narrative_system()
+    node = ns.start_story_arc("p1", "test_arc")
+    assert node is not None and node.id == "test_arc_start"
+
+    next_node = ns.make_choice("p1", 0)
+    assert next_node is not None and next_node.id == "next_node"
+
+
+def test_dynamic_quest_and_progress():
+    ns = NarrativeSystem()
+    quest = ns.generate_dynamic_quest(1, "village")
+    assert quest.id in ns.quests
+
+    count = quest.objectives[0].get("count", 1)
+    assert not ns.update_quest_progress(quest.id, 0, count - 1)
+    assert ns.update_quest_progress(quest.id, 0, 1)
+    assert ns.quests[quest.id].is_completed
+
+
+def test_story_summary():
+    ns = create_simple_narrative_system()
+    ns.start_story_arc("p1", "test_arc")
+    ns.make_choice("p1", 0)
+    quest = ns.generate_dynamic_quest(1, "village")
+    count = quest.objectives[0].get("count", 1)
+    ns.update_quest_progress(quest.id, 0, count)
+
+    summary = ns.get_story_summary("p1")
+    assert summary["total_choices"] == 1
+    assert summary["completed_quests"] >= 1


### PR DESCRIPTION
## Summary
- improve test environment in conftest
- add narrative system unit tests
- add GameService unit tests
- add more API integration tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858ac2892588328aa0406782185d34a