### PR TITLE
Add CI workflow and badge

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -1,0 +1,30 @@
+name: Python CI
+
+on:
+  push:
+    branches: [ "main", "master" ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install ruff
+      - name: Lint with ruff
+        run: ruff check . --output-format=github --exit-zero
+      - name: Run tests
+        run: |
+          pytest --junitxml=pytest-report.xml
+      - name: Upload pytest report
+        uses: actions/upload-artifact@v4
+        with:
+          name: pytest-report
+          path: pytest-report.xml

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # 仙侠世界引擎 (XianXia World Engine)
 
+![CI](https://github.com/cssius111/xianxia-world-engine/actions/workflows/python-ci.yml/badge.svg)
+
 本项目是一个基于文本的仙侠世界模拟器，提供控制台和Web界面两种运行方式。核心功能位于`xwe`包中，`api`目录提供REST接口，`entrypoints`目录包含启动脚本。
 
 ## 安装与运行


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run tests and ruff checks
- show workflow status badge in README

## Testing
- `pytest -q`
- `ruff check . --output-format=github --exit-zero`

------
https://chatgpt.com/codex/tasks/task_e_6858aee6574c8328a2f88f1bde8486e5