### PR TITLE
Replace emoji icons in roll modal with SVG

### DIFF
--- a/templates/components/roll_modal.html
+++ b/templates/components/roll_modal.html
@@ -81,7 +81,14 @@
                 </div>
 
                 <div class="roll-tips">
-                    <p>💡 提示：不同的属性分配将影响你的游戏体验</p>
+                    <p>
+                        <span class="icon-inline">
+                            <svg width="1em" height="1em" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                                <path d="M2 6a6 6 0 1 1 10.174 4.31c-.203.196-.359.4-.453.619l-.762 1.769A.5.5 0 0 1 10.5 13a.5.5 0 0 1 0 1 .5.5 0 0 1 0 1l-.224.447a1 1 0 0 1-.894.553H6.618a1 1 0 0 1-.894-.553L5.5 15a.5.5 0 0 1 0-1 .5.5 0 0 1 0-1 .5.5 0 0 1-.46-.302l-.761-1.77a2 2 0 0 0-.453-.618A5.98 5.98 0 0 1 2 6m6-5a5 5 0 0 0-3.479 8.592c.263.254.514.564.676.941L5.83 12h4.342l.632-1.467c.162-.377.413-.687.676-.941A5 5 0 0 0 8 1"/>
+                            </svg>
+                        </span>
+                        提示：不同的属性分配将影响你的游戏体验
+                    </p>
                 </div>
             </div>
 
@@ -130,12 +137,21 @@
 
         <div class="roll-footer">
             <button class="roll-btn roll-btn-secondary" onclick="RollSystem.randomAll()">
-                <span class="btn-icon">🎲</span>
+                <span class="btn-icon">
+                    <svg width="1em" height="1em" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                        <path d="M13 1a2 2 0 0 1 2 2v10a2 2 0 0 1-2 2H3a2 2 0 0 1-2-2V3a2 2 0 0 1 2-2zM3 0a3 3 0 0 0-3 3v10a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3V3a3 3 0 0 0-3-3z"/>
+                        <path d="M5.5 4a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0m8 8a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0m-4-4a1.5 1.5 0 1 1-3 0 1.5 1.5 0 0 1 3 0"/>
+                    </svg>
+                </span>
                 随机生成
             </button>
 
             <button class="roll-btn roll-btn-primary" onclick="RollSystem.confirmCharacter()">
-                <span class="btn-icon">✓</span>
+                <span class="btn-icon">
+                    <svg width="1em" height="1em" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+                        <path d="M10.97 4.97a.75.75 0 0 1 1.07 1.05l-3.99 4.99a.75.75 0 0 1-1.08.02L4.324 8.384a.75.75 0 1 1 1.06-1.06l2.094 2.093 3.473-4.425z"/>
+                    </svg>
+                </span>
                 确认创建
             </button>
         </div>
@@ -455,6 +471,14 @@
 
 .btn-icon {
     font-size: 20px;
+}
+
+.icon-inline {
+    display: inline-block;
+    width: 1em;
+    height: 1em;
+    vertical-align: -0.1em;
+    margin-right: 4px;
 }
 
 /* 滚动条 */


### PR DESCRIPTION
## Summary
- swap emoji icons for SVG-based icons in the roll modal
- add helper CSS class for inline icons

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68590ea36e1483288f09d16704f71cf8