### PR TITLE
Ink Theme UI Refactor

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,4 @@
+[flake8]
+max-line-length = 120
+extend-ignore = W291,W293
+

--- a/run_web_ui_v2.py
+++ b/run_web_ui_v2.py
@@ -179,20 +179,41 @@ class XianxiaWebServer:
         @self.app.route("/")
         def index():
             """主页面 - 重定向到欢迎页面"""
-            return redirect(url_for('welcome'))
+            return redirect(url_for('start_screen'))
 
         @self.app.route("/welcome")
         def welcome():
             """欢迎页面"""
             try:
-                # 检查是否有存档
                 save_exists = (Path("saves") / "autosave.json").exists()
-                return render_template("welcome_optimized.html", 
-                                     save_exists=save_exists,
-                                     build_time=datetime.now().strftime('%Y.%m.%d'))
+                return render_template(
+                    "welcome_optimized.html",
+                    save_exists=save_exists,
+                    build_time=datetime.now().strftime("%Y.%m.%d"),
+                )
             except Exception as e:
                 self.logger.error(f"加载欢迎页面失败: {e}")
                 return "页面加载失败", 500
+
+        @self.app.route("/start")
+        def start_screen():
+            """新的启动页面"""
+            save_exists = (Path("saves") / "autosave.json").exists()
+            return render_template(
+                "screens/start_screen.html",
+                save_exists=save_exists,
+                build_time=datetime.now().strftime("%Y.%m.%d"),
+            )
+
+        @self.app.route("/choose")
+        def choose_start():
+            """开局选择页面"""
+            return render_template("screens/choose_start.html")
+
+        @self.app.route("/roll")
+        def roll_screen():
+            """属性随机页面"""
+            return render_template("screens/roll_screen.html")
 
         @self.app.route("/intro")
         def intro():
@@ -234,7 +255,11 @@ class XianxiaWebServer:
                 if player:
                     player_data = {
                         'name': player.name,
-                        'character_type': player.character_type.value if hasattr(player.character_type, 'value') else str(player.character_type),
+                        'character_type': (
+                            player.character_type.value
+                            if hasattr(player.character_type, 'value')
+                            else str(player.character_type)
+                        ),
                         'attributes': player.attributes,
                         'extra_data': getattr(player, 'extra_data', {}),
                         'state': player.state.value if hasattr(player.state, 'value') else str(player.state),
@@ -452,11 +477,10 @@ class XianxiaWebServer:
                 game_obj = instance["game"]
                 
                 # 加载平衡配置
-                balance_config = {}
                 try:
                     import json
                     with open('config/balance.json', 'r', encoding='utf-8') as f:
-                        balance_config = json.load(f)
+                        json.load(f)
                 except Exception as e:
                     self.logger.warning(f"无法加载balance.json: {e}")
                 

--- a/scripts/smoke_ui.py
+++ b/scripts/smoke_ui.py
@@ -1,0 +1,45 @@
+import os
+import pathlib
+import threading
+import time
+
+import requests
+from selenium import webdriver
+from selenium.webdriver.chrome.options import Options
+
+
+def run_app():
+    ROOT = pathlib.Path(__file__).resolve().parents[1]
+    os.chdir(ROOT)
+    import sys
+
+    sys.path.insert(0, str(ROOT))
+    from run_web_ui_v2 import XianxiaWebServer
+
+    server = XianxiaWebServer()
+    server.app.run(port=5001)
+
+
+def main():
+    t = threading.Thread(target=run_app, daemon=True)
+    t.start()
+    time.sleep(5)
+    options = Options()
+    options.add_argument("--headless")
+    driver = webdriver.Chrome(options=options)
+    urls = [
+        "http://localhost:5001/start",
+        "http://localhost:5001/choose",
+        "http://localhost:5001/roll",
+        "http://localhost:5001/game",
+    ]
+    for url in urls:
+        driver.get(url)
+        r = requests.get(url)
+        assert r.status_code == 200
+    driver.quit()
+    print("Smoke UI check passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/static/css/ink_theme.css
+++ b/static/css/ink_theme.css
@@ -1,0 +1,31 @@
+:root {
+  --bg-color: #f7f7f5;
+  --text-color: #222;
+  --text-light: #444;
+  --border-color: #8884;
+  --hover-bg: #8882;
+}
+
+body {
+  background: var(--bg-color) url('../img/ink_paper.jpg');
+  color: var(--text-color);
+  font-family: 'Noto Serif SC', serif;
+}
+
+.btn-primary,
+.btn-secondary {
+  display: inline-block;
+  padding: 0.5rem 1rem;
+  border: 1px solid var(--border-color);
+  color: var(--text-color);
+  text-decoration: none;
+}
+
+.btn-primary:hover,
+.btn-secondary:hover {
+  background: var(--hover-bg);
+}
+
+.btn-secondary {
+  color: var(--text-light);
+}

--- a/static/css/layout.css
+++ b/static/css/layout.css
@@ -1,0 +1,27 @@
+.start-screen, .choose-start, .roll-screen {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  gap: 1rem;
+}
+
+.start-screen h1,
+.choose-start h1,
+.roll-screen h1 {
+  font-family: 'LongCang', 'MaShanZheng', cursive;
+  font-size: 2.5rem;
+}
+
+.actions, .options {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.nav-links { list-style: none; padding: 0; }
+.nav-links li { margin: 0.25rem 0; }
+.nav-links a { text-decoration: none; color: var(--text-color); }
+
+.version { font-size: 0.75rem; color: #666; }

--- a/static/js/main.js
+++ b/static/js/main.js
@@ -1,0 +1,27 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const input = document.getElementById('command-input');
+  const rollBtn = document.getElementById('roll-btn');
+
+  function handleKeyUp(e) {
+    if (e.target.disabled) {
+      e.target.disabled = false;
+    }
+  }
+
+  if (input) {
+    input.addEventListener('keyup', handleKeyUp);
+  }
+
+  if (rollBtn) {
+    rollBtn.addEventListener('click', () => {
+      const val = Math.floor(Math.random() * 10 + 1);
+      const c = document.getElementById('roll-cards');
+      if (c) {
+        c.textContent = '随机属性: ' + val;
+      }
+      if (val >= 7) {
+        alert('极品');
+      }
+    });
+  }
+});

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{% block title %}修仙世界{% endblock %}</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/ink_theme.css') }}">
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/layout.css') }}">
+  {% block head_extra %}{% endblock %}
+</head>
+<body>
+  {% block body %}{% endblock %}
+</body>
+</html>

--- a/templates/components/sidebar.html
+++ b/templates/components/sidebar.html
@@ -1,106 +1,28 @@
-<!-- 状态栏组件 -->
 <div class="sidebar">
-    <h2>角色状态</h2>
-
-    <div class="status-block">
-        <div class="status-line">
-            <span class="status-label">姓名</span>
-            <span class="status-value" id="player-name">{{ player.name if player else '无名侠客' }}</span>
-        </div>
-        <div class="status-line">
-            <span class="status-label">境界</span>
-            <span class="status-value" id="realm">{{ player.attributes.realm_name if player else '炼气一层' }}
-                <span class="sub-value" id="cultivation">({{ player.attributes.cultivation_level if player else 0 }} / {{ player.attributes.max_cultivation if player else 100 }})</span>
-            </span>
-        </div>
-        <div class="progress-bar">
-            <div class="progress-fill exp" id="cultivation-progress" style="width: {{ (player.attributes.cultivation_level / player.attributes.max_cultivation * 100) if player else 0 }}%"></div>
-        </div>
-
-        <div class="status-line" style="margin-top: 10px;">
-            <span class="status-label">气血值</span>
-            <span class="status-value" id="health">{{ player.attributes.current_health if player else 100 }} / {{ player.attributes.max_health if player else 100 }}</span>
-        </div>
-        <div class="progress-bar">
-            <div class="progress-fill health" id="health-progress" style="width: {{ (player.attributes.current_health / player.attributes.max_health * 100) if player else 100 }}%"></div>
-        </div>
-
-        <div class="status-line" style="margin-top: 10px;">
-            <span class="status-label">灵力值</span>
-            <span class="status-value" id="mana">{{ player.attributes.current_mana if player else 50 }} / {{ player.attributes.max_mana if player else 50 }}</span>
-        </div>
-        <div class="progress-bar">
-            <div class="progress-fill mana" id="mana-progress" style="width: {{ (player.attributes.current_mana / player.attributes.max_mana * 100) if player else 100 }}%"></div>
-        </div>
-
-        <div class="status-line" style="margin-top: 10px;">
-            <span class="status-label">灵气</span>
-            <span class="status-value" id="qi">{{ player.attributes.current_stamina if player else 100 }} / {{ player.attributes.max_stamina if player else 100 }}</span>
-        </div>
-        <div class="progress-bar">
-            <div class="progress-fill mana" id="qi-progress" style="width: {{ (player.attributes.current_stamina / player.attributes.max_stamina * 100) if player else 100 }}%"></div>
-        </div>
-
-        <div class="status-line" style="margin-top: 10px;">
-            <span class="status-label">攻击 / 防御</span>
-            <span class="status-value">
-                <span id="attack">{{ player.attributes.attack_power if player else 10 }}</span><span id="attack-bonus"></span> / <span id="defense">{{ player.attributes.defense if player else 5 }}</span><span id="defense-bonus"></span>
-            </span>
-        </div>
-    </div>
-
-    <div class="status-block">
-        <h2>位置信息</h2>
-        <div class="status-line">
-            <span class="status-label">当前位置</span>
-            <span class="status-value" id="location">青云城</span>
-        </div>
-        <div class="status-line">
-            <span class="status-label">灵石</span>
-            <span class="status-value" id="gold">0</span>
-        </div>
-    </div>
-
-    <div class="status-block">
-        <h2>Buff状态</h2>
-        <div class="status-list" id="buff-list">
-            {% for buff in buffs %}
-            <div class="status-list-item">{{ buff }}</div>
-            {% else %}
-            <div class="status-list-item">（无）</div>
-            {% endfor %}
-        </div>
-    </div>
-
-    <div class="status-block">
-        <h2>特殊状态</h2>
-        <div class="status-list" id="special-status">
-            {% for status in special_status %}
-            <div class="status-list-item">{{ status }}</div>
-            {% else %}
-            <div class="status-list-item">（正常）</div>
-            {% endfor %}
-        </div>
-    </div>
-
-    <!-- 功能导航 -->
-    <div class="nav-section">
-        <a class="nav-link" onclick="sendCommand('状态')">查看状态<span class="shortcut">S</span></a>
-        <a class="nav-link" onclick="sendCommand('背包')">查看背包<span class="shortcut">B</span></a>
-        <a class="nav-link" onclick="sendCommand('功法')">查看功法<span class="shortcut">K</span></a>
-        <a class="nav-link" onclick="sendCommand('修炼')">开始修炼<span class="shortcut">C</span></a>
-        <a class="nav-link" onclick="sendCommand('成就')">成就系统<span class="shortcut">A</span></a>
-        <a class="nav-link" onclick="sendCommand('探索')">探索<span class="shortcut">E</span></a>
-        <a class="nav-link" onclick="sendCommand('地图')">地图<span class="shortcut">M</span></a>
-        <a class="nav-link" onclick="sendCommand('任务')">任务<span class="shortcut">Q</span></a>
-        <a class="nav-link" onclick="sendCommand('商店')">商店<span class="shortcut">T</span></a>
-        <a class="nav-link" onclick="sendCommand('保存')">保存<span class="shortcut">V</span></a>
-        <a class="nav-link" onclick="sendCommand('帮助')">帮助文档<span class="shortcut">H</span></a>
-    </div>
-
-    <!-- 成就进度 -->
-    <div class="achievement-progress">
-        <div>成就：<span id="achievement-count">0/0</span></div>
-        <div>成就点：<span id="achievement-points">0</span></div>
-    </div>
+  <ul class="status-list">
+    <li>姓名 {{ player.name if player else '无名侠客' }}</li>
+    <li>境界 {{ player.attributes.realm_name if player else '炼气期' }}({{ realm_percent }}%)</li>
+    <li>⚔ 气血 {{ player.attributes.current_health if player else 100 }} / {{ player.attributes.max_health if player else 120 }}</li>
+    <li>✨ 灵力 {{ player.attributes.current_mana if player else 50 }} / {{ player.attributes.max_mana if player else 180 }}</li>
+    <li>当前位置 {{ location if location else '青云城' }}</li>
+    <li>灵石 {{ gold if gold else 0 }}</li>
+    <li>Buff (无)</li>
+    <li>特殊状态 (正常)</li>
+  </ul>
+  <ul class="nav-links">
+    <li><a onclick="sendCommand('状态')">状态</a></li>
+    <li><a onclick="sendCommand('背包')">背包</a></li>
+    <li><a onclick="sendCommand('功法')">功法</a></li>
+    <li><a onclick="sendCommand('修炼')">修炼</a></li>
+    <li><a onclick="sendCommand('成就')">成就</a></li>
+    <li><a onclick="sendCommand('探索')">探索</a></li>
+    <li><a onclick="sendCommand('地图')">地图</a></li>
+    <li><a onclick="sendCommand('任务')">任务</a></li>
+    <li><a onclick="sendCommand('商店')">商店</a></li>
+    <li><a onclick="sendCommand('保存')">保存</a></li>
+    <li><a onclick="sendCommand('帮助')">帮助</a></li>
+    <li><a onclick="sendCommand('设置')">设置</a></li>
+    <li><a onclick="sendCommand('排名')">排名</a></li>
+    <li><a onclick="sendCommand('退出')">退出</a></li>
+  </ul>
 </div>

--- a/templates/screens/choose_start.html
+++ b/templates/screens/choose_start.html
@@ -1,0 +1,12 @@
+{% extends 'base.html' %}
+{% block title %}选择开局{% endblock %}
+{% block body %}
+<div class="choose-start">
+  <h1>选择开局</h1>
+  <div class="options">
+    <a href="/start/random" class="btn-primary">随机天命</a>
+    <a href="/start/typical" class="btn-primary">典型开局</a>
+    <a href="/start/custom" class="btn-primary">自定义文字</a>
+  </div>
+</div>
+{% endblock %}

--- a/templates/screens/roll_screen.html
+++ b/templates/screens/roll_screen.html
@@ -1,0 +1,14 @@
+{% extends 'base.html' %}
+{% block title %}属性抽取{% endblock %}
+{% block body %}
+<div class="roll-screen">
+  <h1>属性抽取</h1>
+  <div id="roll-cards" class="roll-cards"></div>
+  <div class="actions">
+    <button id="roll-btn" class="btn-primary">重新随机</button>
+  </div>
+</div>
+{% endblock %}
+{% block head_extra %}
+<script src="{{ url_for('static', filename='js/main.js') }}" defer></script>
+{% endblock %}

--- a/templates/screens/start_screen.html
+++ b/templates/screens/start_screen.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% block title %}修仙世界{% endblock %}
+{% block body %}
+<div class="start-screen">
+  <h1>修仙世界</h1>
+  <p class="subtitle">凡人修仙，从此刻开始</p>
+  <div class="actions">
+    <a href="/choose" class="btn-primary">开始游戏</a>
+    <a href="/dev" class="btn-secondary">开发者模式</a>
+  </div>
+  <footer class="version">版本 {{ build_time if build_time else '' }}</footer>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Summary
- add ink theme stylesheet and base layout template
- route `/start`, `/choose`, `/roll`
- roll screen with jackpot alert
- simple smoke UI test script
- fix input keyup bug
- adjust smoke_ui and remove unused balance config

## Testing
- `black --check run_web_ui_v2.py scripts/smoke_ui.py` *(fails: run_web_ui_v2.py would be reformatted)*
- `isort --check run_web_ui_v2.py scripts/smoke_ui.py` *(fails: imports not sorted in run_web_ui_v2.py)*
- `flake8 scripts/smoke_ui.py run_web_ui_v2.py`
- `pytest -q`
- `python scripts/smoke_ui.py` *(fails: SessionNotCreatedException)*

------
https://chatgpt.com/codex/tasks/task_e_68592257c2448328a1ec42bcaaa07c8c