### PR TITLE
Fix debug env endpoint

### DIFF
--- a/api/v1/dev/dev_routes.py
+++ b/api/v1/dev/dev_routes.py
@@ -14,7 +14,7 @@ dev_bp = Blueprint('dev', __name__)
 def debug_info():
     """获取调试信息"""
     return jsonify({
-        "environment": os.environ.dict,
+        "environment": dict(os.environ),
         "python_version": "3.10",
         "flask_version": "2.3.2"
     })


### PR DESCRIPTION
## Summary
- update environment retrieval in `/api/v1/dev/dev_routes.py`
- make sure `/api/v1/dev/debug` works

## Testing
- `pytest -q tests`
- `python - <<'PY' ...`

------
https://chatgpt.com/codex/tasks/task_e_6859f82aa5888328b99d2a7ff24d114c