### PR TITLE
Add pre-commit configuration and CI hook

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -19,8 +19,11 @@ jobs:
           pip install -r requirements.txt
           pip install ruff
           pip install pytest
+          pip install pre-commit
       - name: Lint with ruff
         run: ruff check . --output-format=github --exit-zero
+      - name: Run pre-commit
+        run: pre-commit run --all-files
       - name: Run tests
         run: |
           pytest --junitxml=pytest-report.xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+- repo: https://github.com/psf/black
+  rev: 23.11.0
+  hooks:
+    - id: black
+- repo: https://github.com/pycqa/isort
+  rev: 5.12.0
+  hooks:
+    - id: isort
+- repo: https://github.com/pycqa/flake8
+  rev: 6.1.0
+  hooks:
+    - id: flake8

--- a/README.md
+++ b/README.md
@@ -12,14 +12,20 @@
    pip install -r requirements.txt
    ```
 
-2. 复制并编辑环境配置
+2. 安装 Git 钩子（pre-commit）
+
+   ```bash
+   pre-commit install
+   ```
+
+3. 复制并编辑环境配置
 
    ```bash
    cp .env.example .env
    # 打开 .env 填写 DEEPSEEK_API_KEY 等变量
    ```
 
-3. 选择运行模式
+4. 选择运行模式
 
    - **控制台模式**
 


### PR DESCRIPTION
## Summary
- add pre-commit config with black, isort and flake8
- document pre-commit install in setup steps
- run pre-commit in CI before tests

## Testing
- `pre-commit run --files README.md .github/workflows/python-ci.yml .pre-commit-config.yaml`
- `pytest -q` *(fails: DeepSeek API authentication error)*

------
https://chatgpt.com/codex/tasks/task_e_6859fb45d9c48328b67445ba37968eb5