### PR TITLE
Clean up references to removed character directory

### DIFF
--- a/docs/cleanup_report_20250624_165100.md
+++ b/docs/cleanup_report_20250624_165100.md
@@ -12,7 +12,6 @@
 
 ## 警告
 
-- ⚠️  发现可疑的嵌套目录: xwe/data/character/xwe
 - ⚠️  发现可疑的嵌套目录: data/restructured
 - ⚠️  发现可疑的嵌套目录: xwe/data/restructured
 - ⚠️  发现可疑的嵌套目录: xwe/data/refactored
@@ -82,7 +81,6 @@
 - 原因: 最新修改时间
 - 涉及文件:
   - xwe/data/character/roll_data.json
-  - xwe/data/character/xwe/data/character/roll_data.json
 
 ### achievement
 - 建议保留: `data/restructured/achievement.json`

--- a/scripts/CLEANUP_GUIDE.md
+++ b/scripts/CLEANUP_GUIDE.md
@@ -12,7 +12,6 @@
    - 同样的配置文件散布在多个目录
 
 2. **混乱的目录结构**
-   - 存在嵌套的重复目录：`xwe/data/character/xwe/data/character/`
    - 三个不同的restructured目录
    - 没有清晰的文件组织规范
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -64,7 +64,6 @@ chmod +x run_cleanup.sh
 
 将混乱的结构：
 ```
-xwe/data/character/xwe/data/character/
 data/restructured/
 xwe/data/restructured/
 xwe/data/refactored/

--- a/scripts/cleanup_duplicates.py
+++ b/scripts/cleanup_duplicates.py
@@ -149,7 +149,6 @@ class ProjectCleaner:
         
         # 查找可疑的嵌套模式
         suspicious_patterns = [
-            "xwe/data/character/xwe",
             "data/restructured",
             "xwe/data/restructured",
             "xwe/data/refactored"
@@ -209,11 +208,6 @@ class ProjectCleaner:
                     "xwe/data/refactored"
                 ],
                 "suggested_location": "data/game_configs"
-            },
-            {
-                "description": "清理嵌套的xwe目录",
-                "affected_dirs": ["xwe/data/character/xwe"],
-                "action": "删除嵌套目录"
             }
         ]
         

--- a/scripts/restructure_project.py
+++ b/scripts/restructure_project.py
@@ -175,11 +175,7 @@ class ProjectRestructurer:
         # 旧版本文件
         if '_old' in filename or '_backup' in filename:
             return True
-        
-        # 嵌套的重复目录中的文件
-        if 'xwe/data/character/xwe' in filepath:
-            return True
-        
+
         return False
     
     def _identify_merge_candidates(self):


### PR DESCRIPTION
## Summary
- remove obsolete references to `xwe/data/character/xwe`
- tidy cleanup docs and scripts
- adjust duplicate cleanup patterns
- simplify restructure deprecation logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685abe139fb08328939474df6f378895