### PR TITLE
Add fortune descriptions with tooltip support

### DIFF
--- a/templates/modals/character_creation.html
+++ b/templates/modals/character_creation.html
@@ -509,9 +509,16 @@
 
                 const fortRes = await fetch('/data/fortune');
                 if (fortRes.ok) {
-                    FORTUNES = await fortRes.json();
-                    Object.values(FORTUNES).forEach(list => {
-                        list.forEach(name => fortuneInfo[name] = name);
+                    const data = await fortRes.json();
+                    FORTUNES = {};
+                    Object.entries(data).forEach(([tier, list]) => {
+                        if (list.length && typeof list[0] === 'string') {
+                            FORTUNES[tier] = list;
+                            list.forEach(name => fortuneInfo[name] = name);
+                        } else {
+                            FORTUNES[tier] = list.map(f => f.name);
+                            list.forEach(f => fortuneInfo[f.name] = f.description);
+                        }
                     });
                 }
             } catch (e) {

--- a/xwe/core/data_loader.py
+++ b/xwe/core/data_loader.py
@@ -221,7 +221,14 @@ class DataLoader:
 
     def get_fortunes(self) -> Dict[str, Any]:
         """获取气运数据"""
-        return self.load_json("character/fortune.json", {})
+        data = self.load_json("character/fortune.json", {})
+
+        # 兼容旧格式，若列表中仍为字符串则转为包含描述的对象
+        for tier, fortunes in data.items():
+            if fortunes and isinstance(fortunes[0], str):
+                data[tier] = [{"name": name, "description": name} for name in fortunes]
+
+        return data
         
     def clear_cache(self) -> None:
         """清除缓存"""

--- a/xwe/data/character/fortune.json
+++ b/xwe/data/character/fortune.json
@@ -1,7 +1,32 @@
 {
-  "tian": ["鸿运齐天", "天命所归", "紫气东来", "龙凤呈祥"],
-  "di": ["风调雨顺", "地利人和", "吉星高照", "瑞气盈门"],
-  "xuan": ["玄机暗藏", "否极泰来", "云开见日", "柳暗花明"],
-  "huang": ["平安是福", "细水长流", "中规中矩", "稳中求进"],
-  "ren": ["时运不济", "坎坷难行", "雾里看花", "步履维艰"]
+  "tian": [
+    { "name": "鸿运齐天", "description": "气运极旺，遇事皆顺" },
+    { "name": "天命所归", "description": "天意所指，事半功倍" },
+    { "name": "紫气东来", "description": "贵人相助，机缘不断" },
+    { "name": "龙凤呈祥", "description": "吉兆降临，前程似锦" }
+  ],
+  "di": [
+    { "name": "风调雨顺", "description": "顺风顺水，行动无阻" },
+    { "name": "地利人和", "description": "得天时地利，众人拥戴" },
+    { "name": "吉星高照", "description": "好运连连，喜事频临" },
+    { "name": "瑞气盈门", "description": "祥瑞满门，凡事顺遂" }
+  ],
+  "xuan": [
+    { "name": "玄机暗藏", "description": "福祸难料，变化莫测" },
+    { "name": "否极泰来", "description": "困境逢生，转机渐显" },
+    { "name": "云开见日", "description": "迷雾散去，前途明朗" },
+    { "name": "柳暗花明", "description": "绝处逢生，终有转机" }
+  ],
+  "huang": [
+    { "name": "平安是福", "description": "平稳为主，不求有功" },
+    { "name": "细水长流", "description": "运势平平，贵在持久" },
+    { "name": "中规中矩", "description": "无大起伏，按部就班" },
+    { "name": "稳中求进", "description": "步步为营，稳扎稳打" }
+  ],
+  "ren": [
+    { "name": "时运不济", "description": "诸事不顺，常遇阻碍" },
+    { "name": "坎坷难行", "description": "步履维艰，多遭挫折" },
+    { "name": "雾里看花", "description": "前路迷茫，难辨方向" },
+    { "name": "步履维艰", "description": "困难重重，进展缓慢" }
+  ]
 }


### PR DESCRIPTION
## Summary
- add descriptions for all fortunes in `fortune.json`
- normalize fortune data in `DataLoader.get_fortunes`
- parse new fortune format in character creation UI

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ac9331e948328a98e22436409abf4