### PR TITLE
Add stub command handler modules

### DIFF
--- a/xwe/core/command/command_processor.py
+++ b/xwe/core/command/command_processor.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import List
+
+
+@dataclass
+class CommandContext:
+    """Context information for command execution."""
+
+    command: str
+    args: dict | None = None
+
+
+@dataclass
+class CommandResult:
+    """Result returned by a command handler."""
+
+    success: bool
+    message: str = ""
+
+
+class CommandPriority(Enum):
+    """Simple command priority enumeration."""
+
+    LOW = auto()
+    NORMAL = auto()
+    HIGH = auto()
+    CRITICAL = auto()
+
+
+class Middleware:
+    """Base middleware class."""
+
+    def before_handle(self, ctx: CommandContext) -> None:  # pragma: no cover - simple hook
+        pass
+
+    def after_handle(self, ctx: CommandContext, result: CommandResult) -> None:  # pragma: no cover - simple hook
+        pass
+
+
+class LoggingMiddleware(Middleware):
+    pass
+
+
+class ValidationMiddleware(Middleware):
+    pass
+
+
+class CooldownMiddleware(Middleware):
+    pass
+
+
+class RateLimitMiddleware(Middleware):
+    pass
+
+
+class CommandHandler:
+    """Base class for command handlers."""
+
+    commands: List[str] = []
+
+    def handle(self, ctx: CommandContext) -> CommandResult:  # pragma: no cover - simple placeholder
+        if ctx.command in self.commands:
+            return CommandResult(True, f"Executed {ctx.command}")
+        return CommandResult(False, "")
+
+
+class CommandProcessor:
+    """Minimal command processor that dispatches commands to handlers."""
+
+    def __init__(self) -> None:
+        self.handlers: List[CommandHandler] = []
+        self.middlewares: List[Middleware] = []
+
+    def add_handler(self, handler: CommandHandler) -> None:
+        self.handlers.append(handler)
+
+    def add_middleware(self, middleware: Middleware) -> None:
+        self.middlewares.append(middleware)
+
+    def process(self, ctx: CommandContext) -> CommandResult:
+        for middleware in self.middlewares:
+            middleware.before_handle(ctx)
+        for handler in self.handlers:
+            result = handler.handle(ctx)
+            if result.success:
+                for middleware in self.middlewares:
+                    middleware.after_handle(ctx, result)
+                return result
+        result = CommandResult(False, "Command not handled")
+        for middleware in self.middlewares:
+            middleware.after_handle(ctx, result)
+        return result

--- a/xwe/core/command/handlers/combat_handler.py
+++ b/xwe/core/command/handlers/combat_handler.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from ..command_processor import CommandContext, CommandHandler, CommandResult
+
+
+class CombatHandler(CommandHandler):
+    """Base handler for combat related commands."""
+
+
+class AttackHandler(CombatHandler):
+    commands = ["attack"]
+
+
+class DefendHandler(CombatHandler):
+    commands = ["defend"]
+
+
+class FleeHandler(CombatHandler):
+    commands = ["flee"]
+
+
+class UseSkillHandler(CombatHandler):
+    commands = ["use_skill"]
+
+
+class CombatCommandHandler(CombatHandler):
+    commands = ["attack", "defend", "flee", "use_skill"]

--- a/xwe/core/command/handlers/cultivation_handler.py
+++ b/xwe/core/command/handlers/cultivation_handler.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from ..command_processor import CommandHandler
+
+
+class CultivationHandler(CommandHandler):
+    """Base class for cultivation related commands."""
+
+
+class CultivateHandler(CultivationHandler):
+    commands = ["cultivate"]
+
+
+class LearnSkillHandler(CultivationHandler):
+    commands = ["learn"]
+
+
+class BreakthroughHandler(CultivationHandler):
+    commands = ["breakthrough"]
+
+
+class UseItemHandler(CultivationHandler):
+    commands = ["use_item"]
+
+
+class CultivationCommandHandler(CultivationHandler):
+    commands = ["cultivate", "learn", "breakthrough", "use_item"]

--- a/xwe/core/command/handlers/info_handler.py
+++ b/xwe/core/command/handlers/info_handler.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from ..command_processor import CommandHandler
+
+
+class InfoHandler(CommandHandler):
+    """Base class for information commands."""
+
+
+class StatusHandler(InfoHandler):
+    commands = ["status"]
+
+
+class InventoryHandler(InfoHandler):
+    commands = ["inventory"]
+
+
+class SkillsHandler(InfoHandler):
+    commands = ["skills"]
+
+
+class MapHandler(InfoHandler):
+    commands = ["map"]

--- a/xwe/core/command/handlers/interaction_handler.py
+++ b/xwe/core/command/handlers/interaction_handler.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from ..command_processor import CommandHandler
+
+
+class InteractionHandler(CommandHandler):
+    """Base class for interaction commands."""
+
+
+class TalkHandler(InteractionHandler):
+    commands = ["talk"]
+
+
+class TradeHandler(InteractionHandler):
+    commands = ["trade"]
+
+
+class PickUpHandler(InteractionHandler):
+    commands = ["pickup"]
+
+
+class InteractionCommandHandler(InteractionHandler):
+    commands = ["talk", "trade", "pickup"]

--- a/xwe/core/command/handlers/movement_handler.py
+++ b/xwe/core/command/handlers/movement_handler.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from ..command_processor import CommandHandler
+
+
+class MovementHandler(CommandHandler):
+    """Handle movement commands."""
+
+    commands = ["move"]
+
+
+class ExploreHandler(CommandHandler):
+    """Handle exploration commands."""
+
+    commands = ["explore"]

--- a/xwe/core/command/handlers/system_handler.py
+++ b/xwe/core/command/handlers/system_handler.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from ..command_processor import CommandHandler
+
+
+class SystemHandler(CommandHandler):
+    """Base class for system commands."""
+
+
+class SaveHandler(SystemHandler):
+    commands = ["save"]
+
+
+class LoadHandler(SystemHandler):
+    commands = ["load"]
+
+
+class HelpHandler(SystemHandler):
+    commands = ["help"]
+
+
+class QuitHandler(SystemHandler):
+    commands = ["quit"]
+
+
+class SystemCommandHandler(SystemHandler):
+    commands = ["help", "save", "load", "quit"]


### PR DESCRIPTION
## Summary
- implement a minimal `command_processor` module
- add placeholder handler modules for combat, movement, interaction, system, info and cultivation
- verify `xwe.core.command` imports cleanly

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685b466402f48328a73b47be040159fa