### PR TITLE
为世界数据添加数值ID

### DIFF
--- a/xwe/core/data_loader.py
+++ b/xwe/core/data_loader.py
@@ -15,14 +15,14 @@ logger = logging.getLogger(__name__)
 class DataLoader:
     """
     数据加载器
-    
+
     从文件系统加载游戏数据
     """
-    
+
     def __init__(self, data_path: Optional[Path] = None):
         """
         初始化数据加载器
-        
+
         Args:
             data_path: 数据文件路径
         """
@@ -31,35 +31,35 @@ class DataLoader:
             self.data_path = Path(__file__).parent.parent / "data"
         else:
             self.data_path = Path(data_path)
-            
+
         # 缓存已加载的数据
         self._cache: Dict[str, Any] = {}
-        
+
         # 确保数据目录存在
         self.data_path.mkdir(parents=True, exist_ok=True)
-        
+
         logger.info(f"数据加载器初始化，数据路径: {self.data_path}")
-        
+
     def load_json(self, filename: str, default: Any = None) -> Any:
         """
         加载JSON文件
-        
+
         Args:
             filename: 文件名
             default: 默认值
-            
+
         Returns:
             加载的数据或默认值
         """
         # 检查缓存
         if filename in self._cache:
             return self._cache[filename]
-            
+
         filepath = self.data_path / filename
-        
+
         try:
             if filepath.exists():
-                with open(filepath, 'r', encoding='utf-8') as f:
+                with open(filepath, "r", encoding="utf-8") as f:
                     data = json.load(f)
                     self._cache[filename] = data
                     logger.debug(f"成功加载数据文件: {filename}")
@@ -70,24 +70,24 @@ class DataLoader:
         except Exception as e:
             logger.error(f"加载数据文件失败 {filename}: {e}")
             return default if default is not None else {}
-            
+
     def save_json(self, filename: str, data: Any) -> bool:
         """
         保存JSON文件
-        
+
         Args:
             filename: 文件名
             data: 要保存的数据
-            
+
         Returns:
             是否成功保存
         """
         filepath = self.data_path / filename
-        
+
         try:
-            with open(filepath, 'w', encoding='utf-8') as f:
+            with open(filepath, "w", encoding="utf-8") as f:
                 json.dump(data, f, ensure_ascii=False, indent=2)
-                
+
             # 更新缓存
             self._cache[filename] = data
             logger.debug(f"成功保存数据文件: {filename}")
@@ -95,125 +95,167 @@ class DataLoader:
         except Exception as e:
             logger.error(f"保存数据文件失败 {filename}: {e}")
             return False
-            
+
     def get_player_template(self) -> Dict[str, Any]:
         """获取玩家角色模板"""
-        template = self.load_json("templates/player_template.json", {
-            "initial_state": {
-                "name": "无名侠客",
-                "base_attributes": {
-                    "strength": 10,
-                    "constitution": 10,
-                    "agility": 10,
-                    "intelligence": 10,
-                    "willpower": 10,
-                    "comprehension": 10,
-                    "luck": 10
+        template = self.load_json(
+            "templates/player_template.json",
+            {
+                "initial_state": {
+                    "name": "无名侠客",
+                    "base_attributes": {
+                        "strength": 10,
+                        "constitution": 10,
+                        "agility": 10,
+                        "intelligence": 10,
+                        "willpower": 10,
+                        "comprehension": 10,
+                        "luck": 10,
+                    },
+                    "cultivation": {"realm": "凡人", "level": 0},
                 },
-                "cultivation": {
-                    "realm": "凡人",
-                    "level": 0
-                }
+                "initial_skills": ["basic_attack"],
+                "initial_items": {"healing_pill": 5, "spirit_stones": 100},
             },
-            "initial_skills": ["basic_attack"],
-            "initial_items": {
-                "healing_pill": 5,
-                "spirit_stones": 100
-            }
-        })
+        )
         return template
-        
+
     def get_npc_templates(self) -> Dict[str, Any]:
         """获取NPC模板"""
-        return self.load_json("templates/npc_templates.json", {
-            "npcs": [
-                {
-                    "id": "npc_wang_boss",
-                    "name": "王老板",
-                    "type": "npc",
-                    "base_attributes": {
-                        "strength": 8,
-                        "constitution": 12,
-                        "agility": 6,
-                        "intelligence": 15,
-                        "willpower": 10,
-                        "comprehension": 8,
-                        "luck": 12
-                    },
-                    "ai_profile": "merchant",
-                    "location": "青云城"
-                }
-            ]
-        })
+        return self.load_json(
+            "templates/npc_templates.json",
+            {
+                "npcs": [
+                    {
+                        "id": "npc_wang_boss",
+                        "name": "王老板",
+                        "type": "npc",
+                        "base_attributes": {
+                            "strength": 8,
+                            "constitution": 12,
+                            "agility": 6,
+                            "intelligence": 15,
+                            "willpower": 10,
+                            "comprehension": 8,
+                            "luck": 12,
+                        },
+                        "ai_profile": "merchant",
+                        "location": "青云城",
+                    }
+                ]
+            },
+        )
 
     def get_character_templates(self) -> Dict[str, Any]:
         """获取角色模板"""
         return self.load_json("character/templates.json", {})
-        
+
     def get_skill_definitions(self) -> Dict[str, Any]:
         """获取技能定义"""
-        return self.load_json("skills/skill_definitions.json", {
-            "skills": {
-                "basic_attack": {
-                    "id": "basic_attack",
-                    "name": "基础攻击",
-                    "description": "最基本的攻击方式",
-                    "damage_multiplier": 1.0,
-                    "mana_cost": 0,
-                    "cooldown": 0,
-                    "target_type": "single_enemy"
-                },
-                "power_strike": {
-                    "id": "power_strike",
-                    "name": "力量打击",
-                    "description": "消耗体力进行的强力攻击",
-                    "damage_multiplier": 1.5,
-                    "stamina_cost": 10,
-                    "cooldown": 2,
-                    "target_type": "single_enemy"
+        return self.load_json(
+            "skills/skill_definitions.json",
+            {
+                "skills": {
+                    "basic_attack": {
+                        "id": "basic_attack",
+                        "name": "基础攻击",
+                        "description": "最基本的攻击方式",
+                        "damage_multiplier": 1.0,
+                        "mana_cost": 0,
+                        "cooldown": 0,
+                        "target_type": "single_enemy",
+                    },
+                    "power_strike": {
+                        "id": "power_strike",
+                        "name": "力量打击",
+                        "description": "消耗体力进行的强力攻击",
+                        "damage_multiplier": 1.5,
+                        "stamina_cost": 10,
+                        "cooldown": 2,
+                        "target_type": "single_enemy",
+                    },
                 }
-            }
-        })
-        
+            },
+        )
+
     def get_item_definitions(self) -> Dict[str, Any]:
         """获取物品定义"""
-        return self.load_json("items/item_definitions.json", {
-            "items": {
-                "healing_pill": {
-                    "id": "healing_pill",
-                    "name": "回血丹",
-                    "description": "恢复少量生命值",
-                    "type": "consumable",
-                    "effect": {"heal": 50},
-                    "value": 10
-                },
-                "spirit_stones": {
-                    "id": "spirit_stones",
-                    "name": "灵石",
-                    "description": "修仙界通用货币",
-                    "type": "currency",
-                    "stack_size": 9999
+        return self.load_json(
+            "items/item_definitions.json",
+            {
+                "items": {
+                    "healing_pill": {
+                        "id": "healing_pill",
+                        "name": "回血丹",
+                        "description": "恢复少量生命值",
+                        "type": "consumable",
+                        "effect": {"heal": 50},
+                        "value": 10,
+                    },
+                    "spirit_stones": {
+                        "id": "spirit_stones",
+                        "name": "灵石",
+                        "description": "修仙界通用货币",
+                        "type": "currency",
+                        "stack_size": 9999,
+                    },
                 }
-            }
-        })
-        
+            },
+        )
+
     def get_world_config(self) -> Dict[str, Any]:
         """获取世界配置"""
-        return self.load_json("world/world_config.json", {
-            "regions": [],
-            "areas": [],
-            "events": []
-        })
-        
+        data = self.load_json(
+            "world/world_config.json", {"regions": [], "areas": [], "events": []}
+        )
+
+        energy_layer = data.get("energy_layer", {})
+        energy_layer["base_energies"] = self._ensure_entities_with_ids(
+            energy_layer.get("base_energies", [])
+        )
+        start_id = len(energy_layer["base_energies"]) + 1
+        energy_layer["alternate_energies"] = self._ensure_entities_with_ids(
+            energy_layer.get("alternate_energies", []), start_id
+        )
+
+        energy_id_map = {
+            e["name"]: e["id"] for e in energy_layer.get("base_energies", [])
+        }
+        energy_id_map.update(
+            {e["name"]: e["id"] for e in energy_layer.get("alternate_energies", [])}
+        )
+
+        plane_map = energy_layer.get("plane_energy_map", {})
+        for plane, energies in plane_map.items():
+            if isinstance(energies, str):
+                plane_map[plane] = energy_id_map.get(energies, energies)
+            elif isinstance(energies, list):
+                plane_map[plane] = [energy_id_map.get(e, e) for e in energies]
+
+        social_layer = data.get("social_layer", {})
+        social_layer["factions"] = self._ensure_entities_with_ids(
+            social_layer.get("factions", [])
+        )
+
+        karma_layer = data.get("karma_layer", {})
+        karma_layer["trackable_behaviors"] = self._ensure_entities_with_ids(
+            karma_layer.get("trackable_behaviors", [])
+        )
+
+        behavior_layer = data.get("behavior_layer", {})
+        behavior_layer["action_types"] = self._ensure_entities_with_ids(
+            behavior_layer.get("action_types", [])
+        )
+
+        return data
+
     def get_dialogue_trees(self) -> Dict[str, Any]:
         """获取对话树"""
         return self.load_json("dialogues/dialogue_trees.json", {})
-        
+
     def get_event_definitions(self) -> Dict[str, Any]:
         """获取事件定义"""
-        return self.load_json("events/event_definitions.json", {
-            "events": []
-        })
+        return self.load_json("events/event_definitions.json", {"events": []})
 
     def get_destinies(self) -> Dict[str, Any]:
         """获取命格数据"""
@@ -229,17 +271,33 @@ class DataLoader:
                 data[tier] = [{"name": name, "description": name} for name in fortunes]
 
         return data
-        
+
     def clear_cache(self) -> None:
         """清除缓存"""
         self._cache.clear()
         logger.debug("数据缓存已清除")
-        
+
     def reload_data(self, filename: str) -> Any:
         """重新加载数据文件"""
         # 从缓存中移除
         if filename in self._cache:
             del self._cache[filename]
-            
+
         # 重新加载
         return self.load_json(filename)
+
+    @staticmethod
+    def _ensure_entities_with_ids(
+        entities: List[Any], start_index: int = 1
+    ) -> List[Dict[str, Any]]:
+        """确保列表中的元素包含连续的数值ID"""
+        result = []
+        current_id = start_index
+        for item in entities:
+            if isinstance(item, dict):
+                item.setdefault("id", current_id)
+                result.append(item)
+            else:
+                result.append({"id": current_id, "name": item})
+            current_id += 1
+        return result

--- a/xwe/data/world/world_config.json
+++ b/xwe/data/world/world_config.json
@@ -5,28 +5,36 @@
     "description": "此文件定义了修仙世界的六层运行逻辑，用于驱动所有世界行为、成长、冲突与事件反馈。"
   },
   "energy_layer": {
-    "base_energies": ["灵气", "仙气", "本源力"],
+    "base_energies": [
+      {"id": 1, "name": "灵气"},
+      {"id": 2, "name": "仙气"},
+      {"id": 3, "name": "本源力"},
+      {"id": 4, "name": "信仰之力"}
+    ],
     "alternate_energies": [
       {
+        "id": 5,
         "name": "魔气",
         "effects": "可短期提升实力，具侵蚀性",
         "side_effect": "心魔滋生，肉身异化"
       },
       {
+        "id": 6,
         "name": "鬼气",
         "effects": "增强灵魂掌控，操控死物",
         "side_effect": "阳气衰败，容易失控"
       },
       {
+        "id": 7,
         "name": "命火",
         "effects": "以寿元换取爆发力",
         "side_effect": "不可逆生命损耗"
       }
     ],
     "plane_energy_map": {
-      "凡界": "灵气",
-      "仙界": "仙气",
-      "神界": ["本源力", "信仰之力"]
+      "凡界": 1,
+      "仙界": 2,
+      "神界": [3, 4]
     }
   },
   "cultivation_layer": {
@@ -43,7 +51,12 @@
     "system_intervention_allowed": false
   },
   "social_layer": {
-    "factions": ["宗门", "朝廷", "散修联盟", "秘境组织"],
+    "factions": [
+      {"id": 1, "name": "宗门"},
+      {"id": 2, "name": "朝廷"},
+      {"id": 3, "name": "散修联盟"},
+      {"id": 4, "name": "秘境组织"}
+    ],
     "resource_distribution": "不均，势力越强掌控越多",
     "conflict_model": {
       "modes": ["明战", "暗斗", "因果压制", "挑战制度"],
@@ -51,7 +64,14 @@
     }
   },
   "karma_layer": {
-    "trackable_behaviors": ["杀戮", "立誓", "救援", "破誓", "善意施予", "因果交易"],
+    "trackable_behaviors": [
+      {"id": 1, "name": "杀戮"},
+      {"id": 2, "name": "立誓"},
+      {"id": 3, "name": "救援"},
+      {"id": 4, "name": "破誓"},
+      {"id": 5, "name": "善意施予"},
+      {"id": 6, "name": "因果交易"}
+    ],
     "karma_accumulation": {
       "model": "行为加权评分系统",
       "impact": ["NPC态度变化", "天劫强度", "剧情概率分支"]
@@ -64,7 +84,12 @@
   },
   "behavior_layer": {
     "player_input_mode": "自然语言 + 指令关键词",
-    "action_types": ["即时行为", "时间型行为", "循环修炼", "探索型行为"],
+    "action_types": [
+      {"id": 1, "name": "即时行为"},
+      {"id": 2, "name": "时间型行为"},
+      {"id": 3, "name": "循环修炼"},
+      {"id": 4, "name": "探索型行为"}
+    ],
     "time_progression_model": "行为触发 + 世界同步更新",
     "status_visibility": ["位置", "境界", "修炼状态", "正在行动", "外部因果变化"]
   },


### PR DESCRIPTION
## Summary
- 更新 `world_config.json`，为能量、阵营及行为等实体加入 `id` 字段
- 调整 `DataLoader.get_world_config`，加载数据时兼容新的数值标识

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b4689db0083288547eae43a4828b0