### PR TITLE
Add /start route and font styles

### DIFF
--- a/run.py
+++ b/run.py
@@ -175,6 +175,14 @@ def intro_screen():
     return render_template("intro_optimized.html", dev_mode=dev_mode)
 
 
+# 新的开始页面路由，渲染角色创建并显示欢迎模态框
+@app.route("/start")
+def start_screen():
+    """开始页面"""
+    dev_mode = request.args.get("mode") == "dev"
+    return render_template("intro_optimized.html", dev_mode=dev_mode)
+
+
 @app.route("/game")
 def game_screen():
     """游戏主界面"""

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -4,6 +4,15 @@
 @import url('ink_theme.css');
 @import url('layout.css');
 
+/* 字体定义 */
+@font-face {
+    font-family: 'LongCang';
+    src: url('../font/LongCang-Regular.woff2') format('woff2');
+    font-weight: normal;
+    font-style: normal;
+    font-display: swap;
+}
+
 /* 全局重置 */
 * {
     margin: 0;
@@ -465,4 +474,15 @@ tbody + tbody {
     h3 {
         page-break-after: avoid;
     }
+}
+
+/* 标题样式 */
+.title-lg {
+    font-family: 'LongCang', 'KaiTi', serif;
+    font-size: 3rem;
+}
+
+.title-sm {
+    font-family: 'LongCang', 'KaiTi', serif;
+    font-size: 1.5rem;
 }


### PR DESCRIPTION
## Summary
- add `/start` endpoint that serves `intro_optimized.html`
- load `LongCang-Regular.woff2` font and use it for title classes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c0daded5c8328afe2a9dd2bd4296f