### PR TITLE
Remove stamina display from sidebar

### DIFF
--- a/static/css/game_optimized.css
+++ b/static/css/game_optimized.css
@@ -22,7 +22,6 @@
     /* 功能色彩 */
     --health-color: #dc3545;
     --mana-color: #17a2b8;
-    --stamina-color: #28a745;
     --exp-color: #ffc107;
     
     /* 特殊色彩 */
@@ -295,10 +294,6 @@ body::before {
     box-shadow: 0 0 10px rgba(23, 162, 184, 0.3);
 }
 
-.progress-fill.stamina {
-    background: linear-gradient(90deg, var(--stamina-color), #5cb85c);
-    box-shadow: 0 0 10px rgba(40, 167, 69, 0.3);
-}
 
 .progress-fill.exp {
     background: linear-gradient(90deg, var(--exp-color), #ffdf00);

--- a/static/js/game_main.js
+++ b/static/js/game_main.js
@@ -103,12 +103,6 @@ const GameUI = {
         };
         this.updateStatBar('mana', mana.current, mana.max);
         
-        // 更新体力值
-        const stamina = {
-            current: attrs.current_stamina || 100,
-            max: attrs.max_stamina || 100
-        };
-        this.updateStatBar('stamina', stamina.current, stamina.max);
     },
     
     /**

--- a/static/js/game_optimized.js
+++ b/static/js/game_optimized.js
@@ -496,7 +496,6 @@ class XianxiaGameClient {
         // 确保数值在合理范围内
         const curHealth = Math.max(0, Math.min(attrs.current_health || 0, attrs.max_health || 0));
         const curMana = Math.max(0, Math.min(attrs.current_mana || 0, attrs.max_mana || 0));
-        const curStamina = Math.max(0, Math.min(attrs.current_stamina || 0, attrs.max_stamina || 0));
 
         this.updateElement('health', `${curHealth} / ${attrs.max_health || 0}`);
         this.updateElement('mana', `${curMana} / ${attrs.max_mana || 0}`);

--- a/static/js/modules/ui_controller.js
+++ b/static/js/modules/ui_controller.js
@@ -54,7 +54,6 @@ class XianxiaUIController {
             // 属性条
             healthBar: document.querySelector('[data-attribute="health"]'),
             manaBar: document.querySelector('[data-attribute="mana"]'),
-            staminaBar: document.querySelector('[data-attribute="stamina"]'),
             cultivationBar: document.querySelector('[data-attribute="cultivation"]'),
             
             // 功能菜单
@@ -655,7 +654,6 @@ class XianxiaUIController {
         const attributes = [
             { name: 'health', current: 'current_health', max: 'max_health' },
             { name: 'mana', current: 'current_mana', max: 'max_mana' },
-            { name: 'stamina', current: 'current_stamina', max: 'max_stamina' },
             { name: 'cultivation', current: 'cultivation_level', max: 'max_cultivation' }
         ];
         

--- a/templates/components/sidebar_v2.html
+++ b/templates/components/sidebar_v2.html
@@ -48,13 +48,6 @@
             </div>
         </div>
         
-        <div class="stat-item">
-            <span class="stat-label">体力</span>
-            <div class="stat-bar">
-                <div class="stat-fill stamina-fill" id="staminaBar" style="width: 100%"></div>
-                <span class="stat-text" id="staminaText">100/100</span>
-            </div>
-        </div>
     </div>
 </aside>
 
@@ -151,9 +144,6 @@
     background: linear-gradient(90deg, #191970 0%, #4169E1 100%);
 }
 
-.stamina-fill {
-    background: linear-gradient(90deg, #228B22 0%, #32CD32 100%);
-}
 
 .stat-text {
     position: absolute;


### PR DESCRIPTION
## Summary
- drop stamina stat item from sidebar
- remove stamina-related styling
- skip stamina updates in sidebar scripts

## Testing
- `pre-commit run --files static/css/game_optimized.css static/js/game_main.js static/js/game_optimized.js static/js/modules/ui_controller.js templates/components/sidebar_v2.html`

------
https://chatgpt.com/codex/tasks/task_e_685c1224681083289aaccc55feea79b5