### PR TITLE
Add dev mode via query/header

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ python run.py
 
 1. 在开始页面点击"开发者模式"
 2. 输入密码：`dev123`
+3. 或在地址栏添加 `?dev=true`
+4. 也可以在浏览器控制台执行 `localStorage.setItem('dev', 'true')`
 
 ### 开发模式快捷键
 

--- a/routes/character.py
+++ b/routes/character.py
@@ -4,6 +4,7 @@
 """
 
 from flask import Blueprint, current_app, jsonify, request, session
+from run import is_dev_request
 
 from xwe.core.attributes import CharacterAttributes
 from xwe.core.character import Character, CharacterType
@@ -45,6 +46,7 @@ BACKGROUND_BONUSES = {
 def create_character():
     """创建新角色"""
     try:
+        dev_mode = is_dev_request(request)
         data = request.get_json()
 
         # 验证必需字段
@@ -84,7 +86,10 @@ def create_character():
         attrs.max_cultivation = 100
 
         # 根据Roll的属性点分配计算实际属性
-        roll_attrs = panel.sanitize_attributes(data["attributes"])
+        if dev_mode:
+            roll_attrs = {k: int(v) for k, v in data["attributes"].items()}
+        else:
+            roll_attrs = panel.sanitize_attributes(data["attributes"])
 
         # 根骨影响生命值和防御
         constitution = roll_attrs.get("constitution", 5)

--- a/static/js/game_controller.js
+++ b/static/js/game_controller.js
@@ -59,9 +59,14 @@ class XianxiaGameController {
      */
     checkDebugMode() {
         const urlParams = new URLSearchParams(window.location.search);
+        const storageDebug = localStorage.getItem('dev');
         const sessionDebug = sessionStorage.getItem('dev_mode');
-        
-        this.isDebugMode = urlParams.get('mode') === 'dev' || sessionDebug === 'true';
+
+        this.isDebugMode =
+            urlParams.get('dev') === 'true' ||
+            storageDebug === 'true' ||
+            urlParams.get('mode') === 'dev' ||
+            sessionDebug === 'true';
         
         if (this.isDebugMode) {
             document.body.classList.add('dev-mode');
@@ -497,9 +502,11 @@ class XianxiaGameController {
         if (this.isDebugMode) {
             this.enableDebugMode();
             sessionStorage.setItem('dev_mode', 'true');
+            localStorage.setItem('dev', 'true');
         } else {
             this.disableDebugMode();
             sessionStorage.removeItem('dev_mode');
+            localStorage.removeItem('dev');
         }
     }
     

--- a/static/js/game_optimized.js
+++ b/static/js/game_optimized.js
@@ -380,7 +380,8 @@ class XianxiaGameClient {
 
     // 发送命令到服务器
     async sendCommand(command) {
-        const response = await fetch('/command', {
+        const devParam = localStorage.getItem('dev') === 'true' ? '?dev=true' : '';
+        const response = await fetch(`/command${devParam}`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ command })

--- a/static/js/modules/ui_controller.js
+++ b/static/js/modules/ui_controller.js
@@ -297,7 +297,8 @@ class XianxiaUIController {
         
         try {
             // 发送命令到服务器
-            const response = await fetch('/command', {
+            const devParam = localStorage.getItem('dev') === 'true' ? '?dev=true' : '';
+            const response = await fetch(`/command${devParam}`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json',

--- a/static/js/roll.js
+++ b/static/js/roll.js
@@ -121,7 +121,8 @@ async function performRoll() {
             attributes: currentCharacter.attributes,
             destiny: data.destiny && (data.destiny.id || data.destiny.name)
         };
-        await fetch('/create_character', {
+        const devParam = localStorage.getItem('dev') === 'true' ? '?dev=true' : '';
+        await fetch(`/create_character${devParam}`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify(payload)

--- a/templates/components/command_input.html
+++ b/templates/components/command_input.html
@@ -284,7 +284,8 @@ const CommandInput = {
         
         try {
             // 发送命令到服务器（使用 text 字段以支持 NLP）
-            const response = await fetch('/command', {
+            const devParam = localStorage.getItem('dev') === 'true' ? '?dev=true' : '';
+            const response = await fetch(`/command${devParam}`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json'

--- a/templates/components/roll_modal.html
+++ b/templates/components/roll_modal.html
@@ -623,7 +623,8 @@ const RollSystem = {
                 destiny: data.destiny && (data.destiny.id || data.destiny.name)
             };
 
-            const createRes = await fetch('/create_character', {
+            const devParam = localStorage.getItem('dev') === 'true' ? '?dev=true' : '';
+            const createRes = await fetch(`/create_character${devParam}`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(payload)
@@ -669,7 +670,8 @@ const RollSystem = {
 
         // 发送到后端创建角色
         try {
-            const response = await fetch('/create_character', {
+            const devParam = localStorage.getItem('dev') === 'true' ? '?dev=true' : '';
+            const response = await fetch(`/create_character${devParam}`, {
                 method: 'POST',
                 headers: {
                     'Content-Type': 'application/json'


### PR DESCRIPTION
## Summary
- support `dev=true` query param or header in various routes
- skip attribute validation when dev mode is active
- propagate dev flag from frontend requests
- document enabling dev mode in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c44001e488328b9ed7fbb08af8a3f