### PR TITLE
Fix dynamic status

### DIFF
--- a/run.py
+++ b/run.py
@@ -613,20 +613,46 @@ def get_status():
     player_id = session.get("player_id", "default")
     inventory_data = inventory_system.get_inventory_data(player_id)
 
+    player_name = session.get("player_name", "无名侠客")
+    realm_name = "炼气期"
+    realm_level = 1
+    current_health = 100
+    max_health = 100
+    current_mana = 50
+    max_mana = 50
+    location = session.get("location", "青云城")
+
+    if "session_id" in session:
+        try:
+            instance = get_game_instance(session["session_id"])
+            game = instance["game"]
+            player = getattr(game.game_state, "player", None)
+            if player:
+                player_name = player.name
+                realm_name = player.attributes.realm_name
+                realm_level = player.attributes.realm_level
+                current_health = player.attributes.current_health
+                max_health = player.attributes.max_health
+                current_mana = player.attributes.current_mana
+                max_mana = player.attributes.max_mana
+                location = game.game_state.current_location
+        except Exception as e:
+            logger.error(f"读取游戏状态失败: {e}")
+
     return jsonify(
         {
             "player": {
-                "name": session.get("player_name", "无名侠客"),
+                "name": player_name,
                 "attributes": {
-                    "realm_name": "炼气期",
-                    "realm_level": 1,
-                    "current_health": 100,
-                    "max_health": 100,
-                    "current_mana": 50,
-                    "max_mana": 50,
+                    "realm_name": realm_name,
+                    "realm_level": realm_level,
+                    "current_health": current_health,
+                    "max_health": max_health,
+                    "current_mana": current_mana,
+                    "max_mana": max_mana,
                 },
             },
-            "location": session.get("location", "青云城"),
+            "location": location,
             "gold": inventory_data["gold"],
             "inventory": inventory_data,
         }

--- a/tests/test_status.py
+++ b/tests/test_status.py
@@ -1,0 +1,32 @@
+import pytest
+from run import app, get_game_instance
+
+
+def test_status_uses_game_session():
+    with app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess["player_id"] = "player_test"
+            sess["player_name"] = "Tester"
+            sess["session_id"] = "session_test"
+
+        instance = get_game_instance("session_test")
+        game = instance["game"]
+        player = game.game_state.player
+        player.name = "Tester"
+        player.attributes.current_health = 80
+        player.attributes.max_health = 120
+        player.attributes.current_mana = 40
+        player.attributes.max_mana = 60
+        game.game_state.current_location = "TestTown"
+
+        resp = client.get("/status")
+        assert resp.status_code == 200
+        data = resp.get_json()
+        attrs = data["player"]["attributes"]
+        assert attrs["current_health"] == 80
+        assert attrs["max_health"] == 120
+        assert attrs["current_mana"] == 40
+        assert attrs["max_mana"] == 60
+        assert data["player"]["name"] == "Tester"
+        assert data["location"] == "TestTown"
+


### PR DESCRIPTION
## Summary
- dynamically read player health/mana in `/status`
- add test ensuring status data comes from active game session

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c63977aec832899e99bae74978b38