### PR TITLE
Fix startup routes

### DIFF
--- a/run.py
+++ b/run.py
@@ -227,10 +227,9 @@ def index():
 
 @app.route("/welcome")
 def welcome():
-    """欢迎页面 - 新游戏或继续游戏"""
+    """旧版欢迎页面兼容，重定向至角色创建"""
     cleanup_old_instances()
-    save_exists = Path("saves/autosave.json").exists()
-    return render_template("welcome.html", save_exists=save_exists)
+    return redirect(url_for("intro_screen"))
 
 
 @app.route("/intro")
@@ -240,12 +239,14 @@ def intro_screen():
     return render_template("intro_optimized.html", dev_mode=dev_mode)
 
 
-# 新的开始页面路由，渲染角色创建并显示欢迎模态框
+# 兼容旧链接的 /start 路由
 @app.route("/start")
 def start_screen():
-    """开始页面"""
+    """开始页面重定向至角色创建"""
     dev_mode = request.args.get("mode") == "dev"
-    return render_template("intro_optimized.html", dev_mode=dev_mode)
+    if dev_mode:
+        return redirect(url_for("intro_screen", mode="dev"))
+    return redirect(url_for("intro_screen"))
 
 
 @app.route("/game")

--- a/static/js/game_optimized.js
+++ b/static/js/game_optimized.js
@@ -874,7 +874,7 @@ class XianxiaGameClient {
                 <h3 style="font-size: 20px; margin-bottom: 20px; color: #d8d8d8;">确认退出</h3>
                 <p style="margin-bottom: 30px; color: #b8b8b8;">确定要退出游戏吗？未保存的进度将丢失。</p>
                 <div style="display: flex; gap: 20px; justify-content: center;">
-                    <button onclick="window.location.href='/welcome'" 
+                    <button onclick="window.location.href='/intro'"
                         style="padding: 12px 24px; background: #8b0000; color: white; border: none; border-radius: 6px; cursor: pointer; font-size: 14px;">确定退出</button>
                     <button onclick="gameClient.closeModal()" 
                         style="padding: 12px 24px; background: #6b6b6b; color: white; border: none; border-radius: 6px; cursor: pointer; font-size: 14px;">取消</button>

--- a/static/sw.js
+++ b/static/sw.js
@@ -10,7 +10,6 @@ const DYNAMIC_CACHE = 'xianxia-dynamic-v2.0.0';
 // 需要缓存的静态资源
 const STATIC_ASSETS = [
     '/',
-    '/welcome',
     '/intro',
     '/game',
     '/static/css/ink_theme.css',

--- a/templates/modals/character_creation.html
+++ b/templates/modals/character_creation.html
@@ -462,7 +462,7 @@
                 踏入此界
             </button>
             
-            <a href="{{ url_for('welcome') }}" class="action-button">
+            <a href="{{ url_for('intro_screen') }}" class="action-button">
                 返回
             </a>
         </div>

--- a/templates/modals/exit.html
+++ b/templates/modals/exit.html
@@ -36,7 +36,7 @@ async function confirmExit() {
         console.log('自动保存失败');
     }
     
-    // 返回欢迎页面
-    window.location.href = '/welcome';
+    // 返回角色创建页面
+    window.location.href = '/intro';
 }
 </script>


### PR DESCRIPTION
## Summary
- reroute deprecated `/welcome` endpoint to `/intro`
- redirect `/start` to `/intro`
- update front-end links to use `/intro`
- drop `/welcome` from service worker cache

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c6c4e724c8328a5c220fd5b12fb5c