### PR TITLE
Fix env loading for tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,7 @@ DEBUG_MODE=False
 
 # API配置（如果使用外部API）
 # DeepSeek NLP API Key
+# DEEPSEEK_API_KEY=your-key-here
 DEEPSEEK_API_KEY=
 # API_KEY=your-api-key-here
 # API_URL=https://api.example.com

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,9 @@ import importlib.util
 from pathlib import Path
 import werkzeug
 import os
+from dotenv import load_dotenv
+
+load_dotenv()
 
 if not hasattr(werkzeug, "__version__"):
     werkzeug.__version__ = "0"

--- a/xwe/core/nlp/nlp_processor.py
+++ b/xwe/core/nlp/nlp_processor.py
@@ -48,6 +48,10 @@ class DeepSeekNLPProcessor:
         
         # 初始化LLM客户端
         api_key = api_key or self.config.get_api_key()
+        if not api_key:
+            raise ValueError(
+                "Missing DEEPSEEK_API_KEY. Please set it in your environment or .env file."
+            )
         self.llm = LLMClient(
             api_key=api_key,
             api_url=self.config.get("api_url"),


### PR DESCRIPTION
## Summary
- auto-load `.env` for all tests
- provide helpful error when API key missing
- update example env file

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c7adc73a483289676bd771f0b15fc