### PR TITLE
Add env variable for Flask secret key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,7 @@
 FLASK_ENV=development
 FLASK_DEBUG=True
 SECRET_KEY=your-secret-key-here
+FLASK_SECRET_KEY=your-flask-secret-key-here
 
 # 服务器配置
 HOST=0.0.0.0


### PR DESCRIPTION
## Summary
- load secret key from `FLASK_SECRET_KEY` with fallback to `SECRET_KEY`
- document `FLASK_SECRET_KEY` in `.env.example`

## Testing
- `black run.py`
- `isort run.py`
- `flake8 run.py` *(fails: E402 module level import not at top of file)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cb0c832048328bdeb10042775357b