### PR TITLE
修复世界介绍按钮跳转逻辑

### DIFF
--- a/templates/components/world_intro.html
+++ b/templates/components/world_intro.html
@@ -267,10 +267,8 @@ const WorldIntroSystem = {
      * 下一步
      */
     next() {
-        // 获取当前模式
-        const mode = new URLSearchParams(window.location.search).get('mode') || 'player';
-        // 跳转到游戏页面
-        window.location.href = `/game?mode=${mode}`;
+        // 关闭介绍并执行回调
+        this.close();
     },
 
     /**


### PR DESCRIPTION
## Summary
- fix world intro navigation to avoid reloading the game

## Testing
- `pytest -k "not quick" -q` *(fails: cannot connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_685d0e75bc288328b7cb6a41cb61c495