### PR TITLE
Add debug logging to NLP parse

### DIFF
--- a/xwe/core/nlp/nlp_processor.py
+++ b/xwe/core/nlp/nlp_processor.py
@@ -413,7 +413,8 @@ class DeepSeekNLPProcessor:
                 explanation=result.get("explanation", ""),
                 confidence=result.get("confidence", 1.0)
             )
-            
+            logger.debug(f"[NLP] Parsed: {parsed}")
+
             success = True
             return parsed
             
@@ -434,7 +435,8 @@ class DeepSeekNLPProcessor:
                     explanation=fallback_result.get("explanation", "本地回退解析"),
                     confidence=0.5  # 回退解析置信度较低
                 )
-                
+                logger.debug(f"[NLP] Parsed (fallback): {parsed}")
+
                 success = True
                 return parsed
             else:


### PR DESCRIPTION
## Summary
- log the normalized command, intent and args when parsing via the DeepSeek NLP processor
- add similar logging when falling back to local parsing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685debac43848328a1a90d1c09beb74f