### PR TITLE
Add gz handler.namer for rotated logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ xianxia_world_engine/
 │   └── js/               # JavaScript文件
 ├── xwe/                   # 核心模块
 ├── saves/                 # 存档文件
-└── logs/                  # 日志文件
+└── logs/                  # 日志文件，自动轮转并生成 `.gz` 压缩包
 ```
 
 ## 功能特点

--- a/tests/test_log_utils.py
+++ b/tests/test_log_utils.py
@@ -1,0 +1,18 @@
+import logging
+from logging.handlers import RotatingFileHandler
+
+from xwe.utils.log import configure_logging
+
+
+def test_log_handler_namer(tmp_path):
+    logger = logging.getLogger()
+    old_handlers = list(logger.handlers)
+    try:
+        configure_logging(str(tmp_path), "test.log")
+        handler = next(
+            h for h in logger.handlers if isinstance(h, RotatingFileHandler)
+        )
+        assert handler.namer("foo") == "foo.gz"
+    finally:
+        logger.handlers = old_handlers
+

--- a/xwe/utils/log.py
+++ b/xwe/utils/log.py
@@ -26,5 +26,11 @@ def configure_logging(log_dir: str, filename: str = "app.log") -> None:
         Path(source).unlink()
 
     handler.rotator = _rotator
+
+    def _namer(dest: str) -> str:  # pragma: no cover - file renaming
+        """添加 .gz 后缀用于轮转文件"""
+        return dest + ".gz"
+
+    handler.namer = _namer
     logging.getLogger().addHandler(handler)
 


### PR DESCRIPTION
## Summary
- ensure RotatingFileHandler renames compressed log files
- document gzip log rotation in README
- test that configure_logging sets handler.namer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e9af95da88328922f3a53367bf923