### PR TITLE
Prevent duplicate log handlers

### DIFF
--- a/tests/test_log_utils.py
+++ b/tests/test_log_utils.py
@@ -1,4 +1,5 @@
 import logging
+from pathlib import Path
 from logging.handlers import RotatingFileHandler
 
 from xwe.utils.log import configure_logging
@@ -13,6 +14,25 @@ def test_log_handler_namer(tmp_path):
             h for h in logger.handlers if isinstance(h, RotatingFileHandler)
         )
         assert handler.namer("foo") == "foo.gz"
+    finally:
+        logger.handlers = old_handlers
+
+
+def test_no_duplicate_handlers(tmp_path):
+    logger = logging.getLogger()
+    old_handlers = list(logger.handlers)
+    try:
+        configure_logging(str(tmp_path), "test.log")
+        configure_logging(str(tmp_path), "test.log")
+
+        log_path = tmp_path / "test.log"
+        handlers = [
+            h
+            for h in logger.handlers
+            if isinstance(h, RotatingFileHandler)
+            and Path(h.baseFilename) == log_path
+        ]
+        assert len(handlers) == 1
     finally:
         logger.handlers = old_handlers
 

--- a/xwe/utils/log.py
+++ b/xwe/utils/log.py
@@ -18,7 +18,14 @@ def configure_logging(log_dir: str, filename: str = "app.log") -> None:
         format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
     )
 
-    handler = RotatingFileHandler(Path(log_dir) / filename, maxBytes=1024 * 1024, backupCount=5)
+    log_path = Path(log_dir) / filename
+    logger = logging.getLogger()
+
+    for h in logger.handlers:
+        if isinstance(h, RotatingFileHandler) and Path(h.baseFilename) == log_path:
+            return
+
+    handler = RotatingFileHandler(log_path, maxBytes=1024 * 1024, backupCount=5)
 
     def _rotator(source: str, dest: str) -> None:  # pragma: no cover - IO utility
         with open(source, "rb") as sf, gzip.open(dest + ".gz", "wb") as df:
@@ -32,5 +39,5 @@ def configure_logging(log_dir: str, filename: str = "app.log") -> None:
         return dest + ".gz"
 
     handler.namer = _namer
-    logging.getLogger().addHandler(handler)
+    logger.addHandler(handler)
 


### PR DESCRIPTION
## Summary
- avoid adding duplicate RotatingFileHandler in `configure_logging`
- add regression test to ensure a single handler is added

## Testing
- `pytest tests/test_log_utils.py -q`


------
https://chatgpt.com/codex/tasks/task_e_685ea6af1f108328b2682ce34c59e67b