### PR TITLE
Update cache TTL docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,26 @@ xianxia_world_engine/
 - **数据**: JSON文件存储
 - **样式**: 自定义水墨风格主题
 
+## 缓存与 TTL 设置
+
+`config/game_config.py` 提供以下可调参数：
+
+- `data_cache_ttl`：数据文件缓存时间，默认 `300` 秒
+- `smart_cache_ttl`：`SmartCache` 的默认 TTL，默认 `300` 秒
+- `smart_cache_size`：`SmartCache` 缓存上限，默认 `128`
+
+可在代码中修改这些值，例如：
+
+```python
+from config.game_config import config
+
+config.data_cache_ttl = 600
+config.smart_cache_ttl = 60
+config.smart_cache_size = 256
+```
+
+修改后重启游戏即可生效。
+
 ## 贡献指南
 
 欢迎提交 Issue 和 Pull Request！

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -16,6 +16,7 @@
 - [QUICK_START.md](QUICK_START.md) - 快速启动指南
 - [character_design.md](character_design.md) - 角色属性设计
 - [deepseek_nlp_guide.md](deepseek_nlp_guide.md) - DeepSeek NLP 使用说明
+- [cache_settings.md](cache_settings.md) - 缓存与 TTL 设置说明
 - [flask_endpoints.md](flask_endpoints.md) - Flask 端点映射表
 - [test_checklist.md](test_checklist.md) - 测试检查清单
 - [development/](development/) - 开发文档

--- a/docs/cache_settings.md
+++ b/docs/cache_settings.md
@@ -1,0 +1,19 @@
+# 缓存与 TTL 设置
+
+修仙世界引擎提供可调的缓存策略以提升性能。主要选项定义在 `config/game_config.py` 中，默认值如下：
+
+- `data_cache_ttl`：`300` 秒。`DataLoader` 读取的文件在内存中的保存时间。
+- `smart_cache_ttl`：`300` 秒。`SmartCache` 装饰器缓存结果的有效期。
+- `smart_cache_size`：`128`。`SmartCache` 允许存放的最大条目数。
+
+这些选项可以在初始化后通过修改 `config` 实例来调整，例如：
+
+```python
+from config.game_config import config
+
+config.data_cache_ttl = 600       # 文件缓存 10 分钟
+config.smart_cache_ttl = 60       # 智能缓存 1 分钟
+config.smart_cache_size = 256     # 最大缓存 256 项
+```
+
+修改后重新启动游戏即可生效。


### PR DESCRIPTION
## Summary
- document data_cache_ttl and smart cache settings
- reference cache settings doc in docs index
- add cache & TTL section to main README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ea86791e083289d1040dd084be3f4