### PR TITLE
Fix module paths and service inheritance

### DIFF
--- a/run.py
+++ b/run.py
@@ -501,8 +501,12 @@ def api_roll():
     _sys.path.append(str(Path(__file__).parent))
     import random
 
-    from scripts.gen_character import save_character  # noqa: F401
-    from scripts.gen_character import gen_from_prompt, gen_random, gen_template
+    from scripts.dev.gen_character import save_character  # noqa: F401
+    from scripts.dev.gen_character import (
+        gen_from_prompt,
+        gen_random,
+        gen_template,
+    )
 
     data = request.get_json()
     mode = data.get("mode", "random")

--- a/src/xwe/core/game_core.py
+++ b/src/xwe/core/game_core.py
@@ -1829,7 +1829,7 @@ def _setup_enhanced_features(game: GameCore) -> None:
         
         # 添加调试信息输出
         import logging
-        logging.getLogger("src.xwe.).setLevel(logging.DEBUG)
+        logging.getLogger("src.xwe").setLevel(logging.DEBUG)
     
     # 优化性能设置
     if hasattr(game, "config"):

--- a/src/xwe/services/log_service.py
+++ b/src/xwe/services/log_service.py
@@ -4,7 +4,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import List
 
-from src.xwe.services import ServiceBase, ServiceContainer
+from abc import ABC
+from src.xwe.services import IService, ServiceBase, ServiceContainer
 
 
 class LogLevel(Enum):
@@ -25,7 +26,7 @@ class LogFilter:
     level: LogLevel | None = None
 
 
-class ILogService(ServiceBase):
+class ILogService(IService, ABC):
     def log(self, level: LogLevel, message: str) -> None:
         raise NotImplementedError
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,11 +2,18 @@ import pytest
 from flask import Flask
 import importlib.util
 from pathlib import Path
+import sys
 import werkzeug
 import os
 from dotenv import load_dotenv
 
 load_dotenv()
+
+# Ensure the src directory is in sys.path so modules can find 'config' and others
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+SRC_PATH = PROJECT_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
 
 if not hasattr(werkzeug, "__version__"):
     werkzeug.__version__ = "0"
@@ -17,8 +24,8 @@ def _load_module(path, name):
     spec.loader.exec_module(module)  # type: ignore
     return module
 
-game_bp = _load_module('api/v1/game.py', 'game').game_bp
-system_bp = _load_module('api/v1/system.py', 'system').system_bp
+game_bp = _load_module('src/api/v1/game.py', 'game').game_bp
+system_bp = _load_module('src/api/v1/system.py', 'system').system_bp
 
 @pytest.fixture(autouse=True)
 def test_env(monkeypatch):

--- a/tests/unit/test_achievement_system.py
+++ b/tests/unit/test_achievement_system.py
@@ -8,7 +8,7 @@ def _load_module(path, name):
     spec.loader.exec_module(module)  # type: ignore
     return module
 
-ach_module = _load_module('xwe/core/achievement_system.py', 'achievement_system')
+ach_module = _load_module('src/xwe/core/achievement_system.py', 'achievement_system')
 AchievementSystem = ach_module.AchievementSystem
 
 

--- a/tests/unit/test_character_system.py
+++ b/tests/unit/test_character_system.py
@@ -8,10 +8,12 @@ import pytest
 import sys
 from pathlib import Path
 
-# 添加项目根目录到Python路径
-sys.path.insert(0, str(Path(__file__).parent.parent))
+# 添加项目根目录到 Python 路径，便于导入 scripts 模块
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
 
-from scripts.gen_character import gen_random, gen_template
+from scripts.dev.gen_character import gen_random, gen_template
 
 
 class TestCharacterGeneration:

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -9,8 +9,8 @@ def _load_module(path, name):
     spec.loader.exec_module(module)  # type: ignore
     return module
 
-CommandRouter = _load_module('xwe/core/command_router.py', 'command_router').CommandRouter
-Inventory = _load_module('xwe/core/inventory.py', 'inventory').Inventory
+CommandRouter = _load_module('src/xwe/core/command_router.py', 'command_router').CommandRouter
+Inventory = _load_module('src/xwe/core/inventory.py', 'inventory').Inventory
 
 
 def test_command_router_move():

--- a/tests/unit/test_game_service.py
+++ b/tests/unit/test_game_service.py
@@ -40,7 +40,7 @@ stub_services.ServiceBase = StubServiceBase
 stub_services.ServiceContainer = StubServiceContainer
 sys.modules['xwe.services'] = stub_services
 
-game_service_module = _load_module('xwe/services/game_service.py', 'xwe.services.game_service')
+game_service_module = _load_module('src/xwe/services/game_service.py', 'xwe.services.game_service')
 GameService = game_service_module.GameService
 CommandResult = game_service_module.CommandResult
 

--- a/tests/unit/test_optimizations.py
+++ b/tests/unit/test_optimizations.py
@@ -21,7 +21,7 @@ except ImportError:
         spec.loader.exec_module(module)  # type: ignore
         return module
 
-    optimizations = _load_module('src.xwe.core/optimizations/__init__.py', 'optimizations')
+    optimizations = _load_module('src/xwe/core/optimizations/__init__.py', 'optimizations')
     ExpressionJITCompiler = optimizations.ExpressionJITCompiler
     ExpressionBenchmark = optimizations.ExpressionBenchmark
     SmartCache = optimizations.SmartCache


### PR DESCRIPTION
## Summary
- update Flask blueprints to load modules from `src`
- correct paths in unit tests
- ensure character generation API imports from new script location
- fix `ILogService` to inherit from `IService` instead of `ServiceBase`

## Testing
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_686348f4ef848328872efbe4bde250e0