### PR TITLE
Remove verify_e2e script

### DIFF
--- a/cleanup_report.json
+++ b/cleanup_report.json
@@ -5,7 +5,6 @@
     "patch1_e2e_full.diff",
     "patch2_move_legacy.diff",
     "test_quick.py",
-    "verify_e2e.py",
     "generated_characters.jsonl",
     "run-e2e-tests.sh",
     "run-all-e2e-tests.sh",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "test:firefox": "playwright test --project=firefox",
     "test:webkit": "playwright test --project=webkit",
     "test:mobile": "playwright test --project=mobile-chrome",
-    "test:verify": "python verify_e2e.py",
     "test:complete": "./run-all-e2e-tests.sh",
     "test:complete:headless": "./run-all-e2e-tests.sh --headless",
     "install:browsers": "playwright install",

--- a/scripts/maintenance/cleanup_project.py
+++ b/scripts/maintenance/cleanup_project.py
@@ -49,7 +49,6 @@ class ProjectCleaner:
             'patch1_e2e_full.diff',
             'patch2_move_legacy.diff',
             'test_quick.py',
-            'verify_e2e.py',
             'generated_characters.jsonl',
         ]
         


### PR DESCRIPTION
## Summary
- drop `test:verify` script from `package.json`
- remove obsolete references to `verify_e2e.py` in maintenance script and cleanup report

## Testing
- `pip install -r requirements.txt`
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_68634e5c5ddc8328bb809c6ba9d651bd