### PR TITLE
Add pip install step to test docs

### DIFF
--- a/docs/development/PLAYWRIGHT_TEST_README.md
+++ b/docs/development/PLAYWRIGHT_TEST_README.md
@@ -29,6 +29,9 @@ chmod +x run-test.sh
 # 1. 安装依赖
 npm install
 
+# 安装 Python 依赖
+pip install -r requirements.txt
+
 # 2. 安装 Playwright 浏览器
 npx playwright install
 

--- a/docs/development/TEST_INSTRUCTIONS.md
+++ b/docs/development/TEST_INSTRUCTIONS.md
@@ -14,6 +14,9 @@ python3 start_web.py
 ```bash
 cd /Users/chenpinle/Desktop/杂/pythonProject/xianxia_world_engine
 
+# 安装 Python 依赖
+pip install -r requirements.txt
+
 # 安装浏览器（首次运行需要）
 npx playwright install
 

--- a/tests/E2E_COMPLETE_GUIDE.md
+++ b/tests/E2E_COMPLETE_GUIDE.md
@@ -92,6 +92,9 @@
 # 安装 Node.js 依赖
 npm install
 
+# 安装 Python 依赖
+pip install -r requirements.txt
+
 # 安装 Playwright 浏览器
 npx playwright install
 

--- a/tests/E2E_TEST_COMPLETE_GUIDE.md
+++ b/tests/E2E_TEST_COMPLETE_GUIDE.md
@@ -69,6 +69,9 @@
 # 安装Node.js依赖
 npm install
 
+# 安装 Python 依赖
+pip install -r requirements.txt
+
 # 安装Playwright浏览器
 npx playwright install
 ```

--- a/tests/E2E_TEST_README.md
+++ b/tests/E2E_TEST_README.md
@@ -16,6 +16,9 @@
 # 安装 Node.js 依赖
 npm install
 
+# 安装 Python 依赖
+pip install -r requirements.txt
+
 # 安装 Playwright 浏览器
 npx playwright install
 

--- a/tests/QUICK_START.md
+++ b/tests/QUICK_START.md
@@ -10,6 +10,9 @@ chmod +x run-e2e-tests.sh
 # 安装 Node.js 依赖
 npm install
 
+# 安装 Python 依赖
+pip install -r requirements.txt
+
 # 安装 Playwright 浏览器
 npx playwright install
 ```


### PR DESCRIPTION
## Summary
- add Python dependency installation step to E2E README and guides
- keep other docs consistent about installing requirements

## Testing
- `pre-commit run --files docs/development/PLAYWRIGHT_TEST_README.md docs/development/TEST_INSTRUCTIONS.md tests/E2E_TEST_README.md tests/E2E_TEST_COMPLETE_GUIDE.md tests/E2E_COMPLETE_GUIDE.md tests/QUICK_START.md`
- `python run_tests.py` *(fails: ModuleNotFoundError: No module named 'flask')*


------
https://chatgpt.com/codex/tasks/task_e_68634fed95dc8328b253def9e3497dfe