### PR TITLE
Update test and debug docs

### DIFF
--- a/docs/development/SIDEBAR_DEBUG_GUIDE.md
+++ b/docs/development/SIDEBAR_DEBUG_GUIDE.md
@@ -41,19 +41,17 @@ console.log(typeof GamePanels);  // 应该输出 "object"
 - Network标签显示404错误
 
 **解决方案**:
-```python
-# 1. 检查 api_fixes.py 是否被正确导入
-# 在 run.py 中应该有：
-from api_fixes import register_missing_apis
-register_missing_apis(app)
+```bash
+# 检查是否已注册侧边栏 API
+grep -n register_sidebar_apis run.py
 
-# 2. 验证路由注册
-# 添加调试代码到 run.py：
-print("Registered routes:")
-for rule in app.url_map.iter_rules():
-    print(f"  {rule.endpoint}: {rule.rule}")
+# 查看路由
+python - <<'EOF'
+from run import app
+for r in app.url_map.iter_rules():
+    print(r)
+EOF
 ```
-
 ### 问题3: 数据格式错误
 
 **症状**:

--- a/docs/development/TEST_INSTRUCTIONS.md
+++ b/docs/development/TEST_INSTRUCTIONS.md
@@ -5,14 +5,14 @@
 ### 第一步：启动游戏服务器
 在一个终端窗口中运行：
 ```bash
-cd /Users/chenpinle/Desktop/杂/pythonProject/xianxia_world_engine
+cd /path/to/xianxia-world-engine
 python3 start_web.py
 ```
 
 ### 第二步：运行 Playwright 测试
 在另一个终端窗口中运行：
 ```bash
-cd /Users/chenpinle/Desktop/杂/pythonProject/xianxia_world_engine
+cd /path/to/xianxia-world-engine
 
 # 安装 Python 依赖
 pip install -r requirements.txt
@@ -42,4 +42,3 @@ npx playwright show-report
 
 ---
 
-现在让我帮你直接运行测试！

--- a/tests/E2E_COMPLETE_GUIDE.md
+++ b/tests/E2E_COMPLETE_GUIDE.md
@@ -102,14 +102,7 @@ npx playwright install
 npx playwright install-deps
 ```
 
-### 2. 设置执行权限
-```bash
-chmod +x run-all-e2e-tests.sh
-chmod +x run-e2e-tests.sh
-chmod +x test-e2e-verify.sh
-```
-
-### 3. 运行测试
+### 2. 运行测试
 
 #### 完整测试套件（推荐）
 ```bash
@@ -119,8 +112,6 @@ npm run test:complete
 # 无界面模式（CI/CD 环境）
 npm run test:complete:headless
 
-# 或直接运行脚本
-./run-all-e2e-tests.sh
 ```
 
 #### 单独运行测试
@@ -250,7 +241,7 @@ TTL=300                   # 缓存 TTL（秒）
 
 3. **单独测试某个功能**
    ```bash
-   ./run-all-e2e-tests.sh --test "角色创建流程"
+   npx playwright test -g "角色创建流程"
    ```
 
 4. **保留测试产物**

--- a/tests/QUICK_START.md
+++ b/tests/QUICK_START.md
@@ -1,11 +1,6 @@
 # E2E 测试快速开始指南
 
-## 1. 设置权限（Linux/Mac）
-```bash
-chmod +x run-e2e-tests.sh
-```
-
-## 2. 安装依赖
+## 1. 安装依赖
 ```bash
 # 安装 Node.js 依赖
 npm install
@@ -17,7 +12,7 @@ pip install -r requirements.txt
 npx playwright install
 ```
 
-## 3. 注册 E2E API 路由
+## 2. 注册 E2E API 路由
 在 `run.py` 文件中，找到 `app = create_app()` 这一行，在其后添加：
 
 ```python
@@ -31,18 +26,18 @@ if os.getenv('FLASK_ENV') in ['development', 'testing'] or os.getenv('ENABLE_E2E
         logger.debug(f"E2E test routes not loaded: {e}")
 ```
 
-## 4. 运行测试
+## 3. 运行测试
 
-### 方法 1：使用测试脚本（推荐）
+### 方法 1：使用 npm 脚本（推荐）
 ```bash
 # 有界面模式
-./run-e2e-tests.sh
-
-# 无界面模式
-./run-e2e-tests.sh --headless
+npm run test:e2e
 
 # 调试模式
-./run-e2e-tests.sh --debug
+npm run test:e2e:debug
+
+# 无界面模式
+npm run test:e2e:headless
 ```
 
 ### 方法 2：手动运行
@@ -54,13 +49,8 @@ ENABLE_E2E_API=true python run.py
 npx playwright test tests/e2e_full.spec.ts --headed
 ```
 
-### 方法 3：使用 npm 脚本
-```bash
-# 确保服务器已启动，然后：
-npm run test:e2e
-```
 
-## 5. 查看测试结果
+## 4. 查看测试结果
 ```bash
 # 查看 HTML 报告
 npx playwright show-report


### PR DESCRIPTION
## Summary
- fix TEST_INSTRUCTIONS paths and remove leftover sentence
- revise QUICK_START to use npm scripts instead of shell scripts
- clean up E2E_COMPLETE_GUIDE to run tests via npm or npx
- update sidebar debug guide with current steps

## Testing
- `python run_tests.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6863519e78c08328a11cfd4bd4fdc515