### PR TITLE
Add sidebar API Playwright test

### DIFF
--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -1,11 +1,12 @@
 import { defineConfig, devices } from '@playwright/test';
+import * as path from 'path';
 
 /**
  * Xianxia World Engine E2E Test Configuration
  * @see https://playwright.dev/docs/test-configuration
  */
 export default defineConfig({
-  testDir: './tests',
+  testDir: './',
   
   /* Ignore Cypress test files */
   testIgnore: ['**/e2e/*.spec.js', '**/xiuxian-game.spec.js'],
@@ -150,10 +151,11 @@ export default defineConfig({
   /* Run your local dev server before starting the tests */
   webServer: {
     // Use the project's run script to start the server
-    command: process.env.CI ? 'python run.py' : 'python run.py',
+    command: process.env.CI ? 'python start_web.py' : 'python start_web.py',
     port: 5001,
     reuseExistingServer: !process.env.CI,
     timeout: 30_000,
+    cwd: path.join(__dirname, '..', '..'),
     // Wait for the server to be ready
     stdout: 'pipe',
     stderr: 'pipe',
@@ -162,14 +164,15 @@ export default defineConfig({
       FLASK_DEBUG: 'False', // Disable debug for testing
       PORT: '5001',
       ENABLE_E2E_API: 'true', // Enable E2E test routes
+      PYTHONPATH: path.join(__dirname, '..', '..', 'src'),
     },
   },
 
   /* Global setup */
-  globalSetup: require.resolve('./tests/global-setup.ts'),
+  globalSetup: require.resolve('../global-setup.ts'),
   
   /* Global teardown */
-  globalTeardown: require.resolve('./tests/global-teardown.ts'),
+  globalTeardown: require.resolve('../global-teardown.ts'),
 
   /* Output folder for test artifacts */
   outputDir: 'test-results/',

--- a/tests/e2e/sidebar_api.spec.ts
+++ b/tests/e2e/sidebar_api.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@playwright/test';
+
+const getEndpoints = [
+  { url: '/api/cultivation/status', key: 'data' },
+  { url: '/api/achievements', key: 'achievements' },
+  { url: '/api/map', key: 'data' },
+  { url: '/api/quests', key: 'quests' },
+  { url: '/api/intel', key: 'data' },
+  { url: '/api/player/stats/detailed', key: 'data' },
+];
+
+const postEndpoints = [
+  { url: '/api/cultivation/start', data: { hours: 1 }, key: 'result' },
+];
+
+test.describe('侧边栏 API 路由', () => {
+  for (const ep of getEndpoints) {
+    test(`GET ${ep.url}`, async ({ request }) => {
+      const response = await request.get(ep.url);
+      expect(response.status()).toBe(200);
+      const json = await response.json();
+      expect(json).toHaveProperty('success');
+      expect(json).toHaveProperty(ep.key);
+    });
+  }
+
+  for (const ep of postEndpoints) {
+    test(`POST ${ep.url}`, async ({ request }) => {
+      const response = await request.post(ep.url, { data: ep.data });
+      expect(response.status()).toBe(200);
+      const json = await response.json();
+      expect(json).toHaveProperty('success');
+      expect(json).toHaveProperty(ep.key);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- add sidebar_api.spec.ts for verifying new sidebar /api routes
- adjust Playwright config to locate project root and src
- fix testDir and global setup paths

## Testing
- `npx playwright test sidebar_api.spec.ts -c tests/e2e/playwright.config.ts --project=chromium --workers=1`

------
https://chatgpt.com/codex/tasks/task_e_686460cb7490832899a1b2e043b82f42