### PR TITLE
Register intel blueprint

### DIFF
--- a/run.py
+++ b/run.py
@@ -71,6 +71,14 @@ try:
 except ImportError as e:
     logger.debug(f"Lore routes not loaded: {e}")
 
+try:
+    # Register intel routes
+    from src.api.routes.intel import bp as intel_bp
+    app.register_blueprint(intel_bp)
+    logger.info("Intel routes registered")
+except ImportError as e:
+    logger.debug(f"Intel routes not loaded: {e}")
+
 # Register E2E test routes in development/test mode
 if os.getenv('FLASK_ENV') in ['development', 'testing'] or os.getenv('ENABLE_E2E_API') == 'true':
     try:

--- a/tests/unit/test_intel_routes.py
+++ b/tests/unit/test_intel_routes.py
@@ -1,0 +1,16 @@
+import sys
+from pathlib import Path
+
+# Ensure src is in sys.path so run.py can import config and other modules
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / 'src'))
+
+import run
+
+
+def test_intel_tips_endpoint():
+    with run.app.test_client() as client:
+        resp = client.get('/intel/tips')
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert 'tips' in data
+        assert isinstance(data['tips'], list)


### PR DESCRIPTION
## Summary
- register `src.api.routes.intel` blueprint in run.py
- test `/intel/tips` endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686462df3ea083289300d8f003a0ac40