### PR TITLE
Update sidebar guide and fix failing tests

### DIFF
--- a/api_fixes.py
+++ b/api_fixes.py
@@ -1,6 +1,10 @@
 from flask import Blueprint, jsonify, request
 
+# 蓝图: /api 前缀的侧边栏示例接口
 sidebar_api_bp = Blueprint('sidebar_api', __name__, url_prefix='/api')
+
+# 蓝图: /intel 前缀的简化情报接口，避免依赖完整 API 包
+intel_fix_bp = Blueprint('intel_fix', __name__, url_prefix='/intel')
 
 
 @sidebar_api_bp.get('/cultivation/status')
@@ -131,6 +135,37 @@ def intel():
     return jsonify({"success": True, "data": intel_data})
 
 
+@intel_fix_bp.get('/tips')
+def intel_tips():
+    """返回示例游戏提示"""
+    tips = [
+        {
+            "id": "tip_001",
+            "category": "combat",
+            "content": "战斗时注意敌人的攻击模式，适时防御可以减少伤害",
+        },
+        {
+            "id": "tip_002",
+            "category": "cultivation",
+            "content": "修炼时选择灵气充足的地点可以提高效率",
+        },
+        {
+            "id": "tip_003",
+            "category": "social",
+            "content": "与NPC保持良好关系可以获得特殊任务和物品",
+        },
+        {
+            "id": "tip_004",
+            "category": "exploration",
+            "content": "探索时注意周围环境，隐藏的宝物往往在不起眼的地方",
+        },
+    ]
+    category = request.args.get('category')
+    if category:
+        tips = [t for t in tips if t['category'] == category]
+    return jsonify({"tips": tips})
+
+
 @sidebar_api_bp.get('/player/stats/detailed')
 def player_stats_detailed():
     """返回示例详细玩家状态"""
@@ -148,4 +183,5 @@ def player_stats_detailed():
 def register_sidebar_apis(app):
     """注册侧边栏相关API"""
     app.register_blueprint(sidebar_api_bp)
+    app.register_blueprint(intel_fix_bp)
     return sidebar_api_bp

--- a/docs/development/SIDEBAR_DEBUG_GUIDE.md
+++ b/docs/development/SIDEBAR_DEBUG_GUIDE.md
@@ -25,13 +25,10 @@ npx playwright test tests/e2e/sidebar.spec.ts --headed
 
 **解决方案**:
 ```javascript
-// 检查 game_panels_enhanced.js 是否正确加载
 // 在浏览器控制台运行：
 console.log(typeof GamePanels);  // 应该输出 "object"
 
-// 如果是 undefined，检查脚本加载顺序
-// 确保在 HTML 中正确引入：
-<script src="/static/js/game_panels_enhanced.js"></script>
+// 如果是 undefined，检查脚本加载顺序，确认页面已加载相应脚本
 ```
 
 ### 问题2: API 404错误
@@ -156,41 +153,10 @@ chmod +x test_apis.sh
 })();
 ```
 
-### Step 4: 修复脚本
-如果发现问题，运行修复脚本：
+### Step 4: 服务器端检查
 
-```python
-# fix_sidebar.py
-import os
-import json
-
-def check_and_fix_sidebar():
-    """检查并修复侧边栏问题"""
-    
-    # 1. 确保 game_panels_enhanced.js 存在
-    panels_js_path = 'src/web/static/js/game_panels_enhanced.js'
-    if not os.path.exists(panels_js_path):
-        print("❌ game_panels_enhanced.js 不存在")
-        # 这里可以添加创建文件的代码
-    else:
-        print("✅ game_panels_enhanced.js 存在")
-    
-    # 2. 检查 HTML 模板
-    template_path = 'src/web/templates/game_enhanced_optimized_v2.html'
-    if os.path.exists(template_path):
-        with open(template_path, 'r', encoding='utf-8') as f:
-            content = f.read()
-            if 'game_panels_enhanced.js' in content:
-                print("✅ HTML模板正确引用了增强脚本")
-            else:
-                print("❌ HTML模板未引用增强脚本")
-    
-    # 3. 检查API路由
-    # ... 更多检查
-
-if __name__ == '__main__':
-    check_and_fix_sidebar()
-```
+1. 确认在 `run.py` 创建 `Flask` 应用后调用 `register_sidebar_apis(app)`。
+2. 重启服务器并观察终端输出。如果看到 `Sidebar API fixes registered` 日志，则说明补丁已成功加载。
 
 ## 临时解决方案
 

--- a/src/api/__init__.py
+++ b/src/api/__init__.py
@@ -4,7 +4,10 @@ OpenAPI 文档生成器
 """
 
 from flask import Flask, jsonify
-from flask_swagger_ui import get_swaggerui_blueprint
+try:
+    from flask_swagger_ui import get_swaggerui_blueprint
+except Exception:  # noqa: E722 - library may be optional in tests
+    get_swaggerui_blueprint = None
 import os
 
 from .middleware import register_middleware
@@ -31,9 +34,11 @@ def openapi_json():
 
 # 设置 Swagger UI 到 Flask 应用
 def setup_swagger_ui(app):
+    if get_swaggerui_blueprint is None:
+        raise RuntimeError("flask-swagger-ui is not installed")
     swagger_ui = get_swaggerui_blueprint(
-        "/api/docs",  # 文档前端访问路径
-        "/api/openapi.json",  # 文档 JSON 数据源
+        "/api/docs",
+        "/api/openapi.json",
         config={"app_name": "修仙世界引擎 API"},
     )
     app.register_blueprint(swagger_ui, url_prefix="/api/docs")


### PR DESCRIPTION
## Summary
- guard optional `flask_swagger_ui` import to avoid ImportError
- provide `/intel/tips` endpoint via simplified blueprint
- register intel tips blueprint in API fixes
- clarify sidebar debug guide about server log message

## Testing
- `python run_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_68647d63428083289972a4b498e4b346