### PR TITLE
Implement basic attack command

### DIFF
--- a/run.py
+++ b/run.py
@@ -33,6 +33,7 @@ from flask import (
 load_dotenv()
 
 from src.xwe.core.command_router import CommandRouter
+from src.xwe.core.command_router import handle_attack
 from src.xwe.core.cultivation_system import CultivationSystem
 from src.xwe.core.data_loader import DataLoader
 from src.xwe.core.game_core import create_enhanced_game
@@ -715,6 +716,17 @@ def process_command():
                 "parsed_command": {"handler": command_handler, "params": params},
             }
         )
+
+    elif command_handler == "attack":
+        # 普通攻击
+        target = params.get("target", "")
+        instance = get_game_instance(session.get("session_id"))
+        game = instance["game"]
+        attack_result = handle_attack(target, game)
+        return jsonify({
+            **attack_result,
+            "parsed_command": {"handler": command_handler, "params": params},
+        })
 
     elif command_handler == "talk":
         # 对话

--- a/src/xwe/core/combat.py
+++ b/src/xwe/core/combat.py
@@ -235,8 +235,31 @@ class CombatSystem:
             combat = self.active_combats[combat_id]
             combat.is_active = False
             del self.active_combats[combat_id]
-            
+
             logger.info(f"战斗结束: {combat_id}")
+
+    def attack(self, attacker: Any, defender: Any) -> CombatResult:
+        """执行一次简单的攻击并返回结果"""
+        # 创建临时战斗状态以复用伤害计算逻辑
+        temp_combat = CombatState(str(uuid.uuid4()))
+        temp_combat.add_participant(attacker, "attacker")
+        temp_combat.add_participant(defender, "defender")
+
+        result = self._execute_attack(attacker, [defender.id], temp_combat)
+
+        damage = result.damage_dealt.get(defender.id)
+        if damage:
+            if damage.is_evaded:
+                result.message = f"{defender.name} 闪避了攻击！"
+            else:
+                dmg_text = f"{damage.damage:.0f}"
+                if damage.is_critical:
+                    dmg_text = f"暴击！{dmg_text}"
+                result.message = f"你对{defender.name}造成了{dmg_text}点伤害"
+        else:
+            result.message = "攻击未能造成伤害"
+
+        return result
             
     def execute_action(self, combat_id: str, action: CombatAction) -> CombatResult:
         """

--- a/src/xwe/core/command_router.py
+++ b/src/xwe/core/command_router.py
@@ -364,3 +364,32 @@ class CommandRouter:
 
 # 向后兼容的别名
 NLPCommandRouter = CommandRouter
+
+
+def handle_attack(target: str, game: Any) -> Dict[str, Any]:
+    """执行攻击指令并返回战斗日志"""
+    from .combat import CombatSystem  # local import to avoid circular
+    from .character import Character, CharacterType
+    from .attributes import CharacterAttributes
+
+    combat_system: CombatSystem = game.combat_system
+    player = game.game_state.player
+
+    enemy = Character(name=target, character_type=CharacterType.MONSTER,
+                      attributes=CharacterAttributes())
+
+    result = combat_system.attack(player, enemy)
+
+    # 记录战斗日志
+    if hasattr(game.game_state, "logs"):
+        game.game_state.logs.append(result.message)
+
+    return {
+        "success": result.success,
+        "result": result.message,
+        "combat_result": {
+            "damage": result.damage_dealt.get(enemy.id).damage if enemy.id in result.damage_dealt else 0,
+            "target": enemy.name,
+        },
+    }
+

--- a/tests/e2e/e2e_extended.spec.ts
+++ b/tests/e2e/e2e_extended.spec.ts
@@ -55,6 +55,15 @@ test.describe('Extended E2E Tests', () => {
         const data = await response.json();
         expect.soft(data.result).toContain('修炼');
       });
+
+      await test.step('测试攻击命令', async () => {
+        const response = await request.post('/command', {
+          data: { command: '攻击 木桩' }
+        });
+        expect.soft(response.ok()).toBeTruthy();
+        const data = await response.json();
+        expect.soft(data.result).toMatch(/木桩/);
+      });
     });
   });
 

--- a/tests/unit/test_attack_command.py
+++ b/tests/unit/test_attack_command.py
@@ -1,0 +1,26 @@
+import importlib.util
+from pathlib import Path
+from unittest import mock
+from src.xwe.core.combat import CombatResult
+
+
+def _load_run_module():
+    spec = importlib.util.spec_from_file_location("run", Path("run.py"))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore
+    return module
+
+
+def test_attack_command():
+    run = _load_run_module()
+    app = run.app
+    client = app.test_client()
+
+    mock_res = CombatResult(True, "你对木桩造成了10点伤害")
+    with mock.patch("src.xwe.core.combat.CombatSystem.attack", return_value=mock_res):
+        resp = client.post("/command", json={"command": "攻击 木桩"})
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data["success"] is True
+        assert "木桩" in data["result"]
+


### PR DESCRIPTION
## Summary
- add `CombatSystem.attack` helper
- implement `handle_attack` in `command_router`
- support the new `attack` command in `/command`
- test attack command
- extend E2E tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68649cb47f408328a4d78fda7603402a