### PR TITLE
Update tests with Playwright setup

### DIFF
--- a/docs/development/TEST_INSTRUCTIONS.md
+++ b/docs/development/TEST_INSTRUCTIONS.md
@@ -17,8 +17,8 @@ cd /path/to/xianxia-world-engine
 # 安装 Python 依赖
 pip install -r requirements.txt
 
-# 安装浏览器（首次运行需要）
-npx playwright install
+# 安装浏览器和系统依赖（首次运行需要）
+npx playwright install --with-deps
 
 # 运行可视化测试
 npx playwright test --headed --project=chromium xiuxian-game.spec.js

--- a/run_tests.py
+++ b/run_tests.py
@@ -36,11 +36,16 @@ def main():
             print("\n❌ 导入检查失败，请先修复导入错误")
             return 1
     
-    # 2. 运行 pytest（只在 tests 目录）
+    # 2. 安装 Playwright 浏览器及依赖
+    if not run_command("npx playwright install --with-deps", "安装 Playwright 浏览器依赖"):
+        print("\n❌ Playwright 安装失败")
+        return 1
+
+    # 3. 运行 pytest（只在 tests 目录）
     if not run_command("pytest tests/ -v", "运行单元测试"):
         all_passed = False
-    
-    # 3. 生成覆盖率报告（可选）
+
+    # 4. 生成覆盖率报告（可选）
     # run_command("pytest tests/ --cov=xwe --cov-report=html", "生成覆盖率报告")
     
     # 总结


### PR DESCRIPTION
## Summary
- install Playwright dependencies before running tests
- document `npx playwright install --with-deps` in test instructions

## Testing
- `python run_tests.py` *(fails: ModuleNotFoundError: No module named 'werkzeug')*

------
https://chatgpt.com/codex/tasks/task_e_6864f57875fc832898fb65bea84e90d2