### PR TITLE
Add logging level and record tests

### DIFF
--- a/tests/unit/test_log_utils.py
+++ b/tests/unit/test_log_utils.py
@@ -36,3 +36,31 @@ def test_no_duplicate_handlers(tmp_path):
     finally:
         logger.handlers = old_handlers
 
+
+def test_configure_logging_debug_level(tmp_path):
+    logger = logging.getLogger()
+    old_handlers = list(logger.handlers)
+    old_level = logger.level
+    logger.handlers = []
+    logger.setLevel(logging.NOTSET)
+    try:
+        configure_logging(str(tmp_path), "debug.log", level=logging.DEBUG)
+        assert logger.level == logging.DEBUG
+    finally:
+        logger.handlers = old_handlers
+        logger.setLevel(old_level)
+
+
+def test_configure_logging_info_level(tmp_path):
+    logger = logging.getLogger()
+    old_handlers = list(logger.handlers)
+    old_level = logger.level
+    logger.handlers = []
+    logger.setLevel(logging.NOTSET)
+    try:
+        configure_logging(str(tmp_path), "info.log", level=logging.INFO)
+        assert logger.level == logging.INFO
+    finally:
+        logger.handlers = old_handlers
+        logger.setLevel(old_level)
+

--- a/tests/unit/test_logging_caplog.py
+++ b/tests/unit/test_logging_caplog.py
@@ -1,0 +1,43 @@
+import logging
+import json
+import os
+import logging
+
+from src.xwe.core.command_router import CommandRouter
+from src.xwe.core.nlp.nlp_processor import DeepSeekNLPProcessor
+
+
+def test_route_command_logs(caplog):
+    router = CommandRouter(use_nlp=False)
+    with caplog.at_level(logging.DEBUG, logger="xwe.command_router"):
+        cmd, params = router.route_command("移动 北")
+    assert cmd == "move"
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("收到命令文本" in m for m in messages)
+    assert any("传统路由选择处理器" in m and "move" in m for m in messages)
+
+
+def test_nlp_parse_logs(monkeypatch, caplog):
+    os.environ["DEEPSEEK_API_KEY"] = "dummy"
+    sample_result = {
+        "raw": "探索",
+        "normalized_command": "explore",
+        "intent": "action",
+        "args": {},
+        "explanation": "test",
+        "confidence": 1.0,
+    }
+
+    def fake_call(self, prompt):
+        return json.dumps(sample_result)
+
+    monkeypatch.setattr(DeepSeekNLPProcessor, "_call_deepseek_api", fake_call)
+    monkeypatch.setattr(DeepSeekNLPProcessor, "build_prompt", lambda self, text, context=None: text)
+
+    processor = DeepSeekNLPProcessor(api_key="dummy")
+    with caplog.at_level(logging.DEBUG, logger="xwe.nlp"):
+        result = processor.parse("探索", use_cache=False)
+    assert result.normalized_command == "explore"
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("Raw user input: 探索" in m for m in messages)
+    assert any("Parsed command:" in m for m in messages)


### PR DESCRIPTION
## Summary
- expand log utils tests to validate log level configuration
- ensure CommandRouter and NLP parser emit debug/info logs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68652a138320832884d9fb8eeb411381