### PR TITLE
Update debug endpoint

### DIFF
--- a/src/api/v1/dev/dev_routes.py
+++ b/src/api/v1/dev/dev_routes.py
@@ -4,7 +4,8 @@
 """
 
 from flask import Blueprint, jsonify, request
-import os
+import flask
+import sys
 
 # 无论环境如何都先创建蓝图，随后再在外部判断是否导出
 dev_bp = Blueprint('dev', __name__)
@@ -14,9 +15,8 @@ dev_bp = Blueprint('dev', __name__)
 def debug_info():
     """获取调试信息"""
     return jsonify({
-        "environment": dict(os.environ),
-        "python_version": "3.10",
-        "flask_version": "2.3.2"
+        "python_version": sys.version.split(" ")[0],
+        "flask_version": flask.__version__
     })
 
 

--- a/tests/api/test_debug_endpoint.py
+++ b/tests/api/test_debug_endpoint.py
@@ -1,0 +1,17 @@
+import sys
+import flask
+
+
+def test_debug_endpoint_returns_versions(client):
+    from src.api.v1.dev.dev_routes import dev_bp
+
+    app = client.application
+    app.register_blueprint(dev_bp, url_prefix="/api/v1/dev")
+
+    resp = client.get("/api/v1/dev/debug")
+    assert resp.status_code == 200
+    data = resp.get_json()
+
+    assert data["python_version"] == sys.version.split(" ")[0]
+    assert data["flask_version"] == flask.__version__
+    assert "environment" not in data


### PR DESCRIPTION
## Summary
- prune environment info from dev `/debug` endpoint
- return python and flask versions dynamically
- test the updated endpoint

## Testing
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_6868819f3e7c8328a0192a078989b29f