### PR TITLE
Add ruff hook and pytest hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,3 +17,14 @@ repos:
     rev: 6.1.0
     hooks:
       - id: flake8
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.2
+    hooks:
+      - id: ruff
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: pytest -q
+        language: system
+        types: [python]

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 ```bash
 pip install -r requirements.txt
+pre-commit install
 ```
 
 ### 2. 启动游戏

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -21,6 +21,7 @@ python main_menu.py
 ```bash
 chmod +x scripts/*.py
 python scripts/dev/gen_character.py
+pre-commit install
 ```
 
 


### PR DESCRIPTION
## Summary
- enable ruff in pre-commit
- run pytest via custom hook
- mention `pre-commit install` in docs

## Testing
- `pre-commit run --files README.md docs/QUICK_START.md .pre-commit-config.yaml`
- `pytest -q tests/api/test_debug_endpoint.py::test_debug_endpoint_returns_versions`


------
https://chatgpt.com/codex/tasks/task_e_6869b9a5c88c832898442c17e0a87024