### PR TITLE
Add onboarding quest manager

### DIFF
--- a/src/api/routes/__init__.py
+++ b/src/api/routes/__init__.py
@@ -18,6 +18,7 @@ def register_all_routes(app):
     from .map import map_bp
     from .player import player_bp
     from .quests import quests_bp
+    from .onboarding import onboarding_bp
     
     # Register all blueprints
     app.register_blueprint(achievements_bp)
@@ -32,6 +33,7 @@ def register_all_routes(app):
     app.register_blueprint(map_bp)
     app.register_blueprint(player_bp)
     app.register_blueprint(quests_bp)
+    app.register_blueprint(onboarding_bp)
     
     # Register v1 API blueprints
     from ..v1.system import system_bp

--- a/src/api/routes/onboarding.py
+++ b/src/api/routes/onboarding.py
@@ -1,0 +1,28 @@
+from flask import Blueprint, jsonify, request, session
+
+from src.app import inventory_system
+from src.xwe.features.onboarding_manager import OnboardingQuestManager
+
+onboarding_manager = OnboardingQuestManager(inventory_system)
+
+onboarding_bp = Blueprint("onboarding", __name__, url_prefix="/api/onboarding")
+
+
+@onboarding_bp.get("")
+@onboarding_bp.get("/")
+def get_progress():
+    """查询新手任务进度"""
+    player_id = session.get("player_id", "default")
+    progress = onboarding_manager.get_progress(player_id)
+    return jsonify(progress)
+
+
+@onboarding_bp.post("/complete")
+def complete_step():
+    """标记某个步骤完成"""
+    data = request.get_json() or {}
+    step = data.get("step")
+    player_id = session.get("player_id", "default")
+    success = onboarding_manager.complete_step(player_id, step)
+    progress = onboarding_manager.get_progress(player_id)
+    return jsonify({"success": success, "progress": progress})

--- a/src/xwe/features/__init__.py
+++ b/src/xwe/features/__init__.py
@@ -4,5 +4,6 @@
 
 from .exploration_system import ExplorationSystem
 from .inventory_system import InventorySystem
+from .onboarding_manager import OnboardingQuestManager
 
-__all__ = ["ExplorationSystem", "InventorySystem"]
+__all__ = ["ExplorationSystem", "InventorySystem", "OnboardingQuestManager"]

--- a/src/xwe/features/onboarding_manager.py
+++ b/src/xwe/features/onboarding_manager.py
@@ -1,0 +1,62 @@
+"""新手任务管理器
+负责引导玩家完成基础操作并发放奖励
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Optional
+import logging
+
+from .inventory_system import InventorySystem
+
+logger = logging.getLogger(__name__)
+
+
+class OnboardingQuestManager:
+    """管理新手引导任务进度"""
+
+    TASKS = ["status", "inventory", "cultivate", "explore", "attack"]
+
+    def __init__(self, inventory_system: Optional[InventorySystem] = None) -> None:
+        self.inventory_system = inventory_system
+        self.progress: Dict[str, List[str]] = {}
+
+    def get_progress(self, player_id: str) -> Dict[str, any]:
+        """获取玩家的新手任务进度"""
+        completed = self.progress.get(player_id, [])
+        return {
+            "tasks": [
+                {"id": t, "completed": t in completed, "index": i + 1}
+                for i, t in enumerate(self.TASKS)
+            ],
+            "completed_count": len(completed),
+            "total": len(self.TASKS),
+        }
+
+    def complete_step(self, player_id: str, step: str) -> bool:
+        """记录任务步骤完成并发放奖励"""
+        if step not in self.TASKS:
+            logger.warning("无效的新手任务步骤: %s", step)
+            return False
+
+        completed = self.progress.setdefault(player_id, [])
+        if step in completed:
+            return False
+
+        completed.append(step)
+        self._grant_reward(player_id, step)
+        logger.info("玩家 %s 完成新手任务: %s", player_id, step)
+        return True
+
+    # ------------------------------------------------------------------
+    def _grant_reward(self, player_id: str, step: str) -> None:
+        """发放奖励，默认给予少量金币"""
+        if not self.inventory_system:
+            return
+        try:
+            inv = self.inventory_system.get_inventory(player_id)
+            inv.add_gold(10)
+            self.inventory_system.save(player_id)
+            logger.debug("已为 %s 发放新手奖励: gold +10", player_id)
+        except Exception as exc:
+            logger.error("发放新手奖励失败: %s", exc)

--- a/tests/unit/test_onboarding_api.py
+++ b/tests/unit/test_onboarding_api.py
@@ -1,0 +1,25 @@
+import json
+
+
+def test_onboarding_flow(client):
+    # Initialize session
+    with client.session_transaction() as sess:
+        sess["player_id"] = "test_player"
+
+    # Query initial progress
+    resp = client.get("/api/onboarding")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["completed_count"] == 0
+    assert data["total"] == 5
+
+    # Complete first step
+    resp = client.post(
+        "/api/onboarding/complete",
+        data=json.dumps({"step": "status"}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+    result = resp.get_json()
+    assert result["success"] is True
+    assert result["progress"]["completed_count"] == 1


### PR DESCRIPTION
## Summary
- implement `OnboardingQuestManager` to track tutorial steps
- expose new `/api/onboarding` endpoints to query and update progress
- register the new blueprint
- export the manager in `features.__init__`
- add basic tests for onboarding API

## Testing
- `SKIP_PLAYWRIGHT_INSTALL=true pytest tests/unit/test_onboarding_api.py -q`
- `SKIP_PLAYWRIGHT_INSTALL=true python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_6869d34a8a348328b26becbcb183f0c9