### PR TITLE
Implement SSE events for sidebar updates

### DIFF
--- a/src/api/routes/__init__.py
+++ b/src/api/routes/__init__.py
@@ -18,6 +18,7 @@ def register_all_routes(app):
     from .map import map_bp
     from .player import player_bp
     from .quests import quests_bp
+    from .events import events_bp
     from .onboarding import onboarding_bp
     
     # Register all blueprints
@@ -33,6 +34,7 @@ def register_all_routes(app):
     app.register_blueprint(map_bp)
     app.register_blueprint(player_bp)
     app.register_blueprint(quests_bp)
+    app.register_blueprint(events_bp)
     app.register_blueprint(onboarding_bp)
     
     # Register v1 API blueprints

--- a/src/api/routes/events.py
+++ b/src/api/routes/events.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+import time
+from flask import Blueprint, Response, stream_with_context, session
+
+from src.app import build_status_data, status_cache
+
+
+events_bp = Blueprint("events", __name__)
+
+
+def _generate_events():
+    session_id = session.get("session_id", "default")
+    last_data = status_cache.get(session_id)
+    while True:
+        data = build_status_data()
+        subset = {
+            "player": data.get("player", {}),
+            "inventory": data.get("inventory", {}),
+        }
+        if subset != last_data:
+            last_data = subset
+            status_cache[session_id] = subset
+            yield f"data: {json.dumps(subset, ensure_ascii=False)}\n\n"
+        time.sleep(1)
+
+
+@events_bp.route("/events")
+def events_stream():
+    return Response(stream_with_context(_generate_events()), mimetype="text/event-stream")
+
+
+__all__ = ["events_bp"]

--- a/tests/api/test_events_stream.py
+++ b/tests/api/test_events_stream.py
@@ -1,0 +1,12 @@
+import json
+
+
+def test_events_stream(client):
+    response = client.get('/events', buffered=False)
+    # Read first chunk from the event stream
+    first_chunk = next(response.response)
+    assert b'data:' in first_chunk
+    data_json = first_chunk.decode().split('data:')[1].strip()
+    data = json.loads(data_json)
+    assert 'player' in data
+    assert 'inventory' in data


### PR DESCRIPTION
## Summary
- create `events_bp` for SSE at `/events`
- register new blueprint in API
- update game controller to connect to `/events`
- add new API test for events stream

## Testing
- `pytest tests/api/test_events_stream.py -vv`
- `SKIP_PLAYWRIGHT_INSTALL=true python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_6869d8b58e44832885a085651e451448