### PR TITLE
Add random event modal and API

### DIFF
--- a/src/api/routes/events.py
+++ b/src/api/routes/events.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import time
-from flask import Blueprint, Response, stream_with_context, session
+from flask import Blueprint, Response, stream_with_context, session, jsonify, request, current_app
 
 from src.app import build_status_data, status_cache
 
@@ -29,6 +29,27 @@ def _generate_events():
 @events_bp.route("/events")
 def events_stream():
     return Response(stream_with_context(_generate_events()), mimetype="text/event-stream")
+
+
+@events_bp.get("/api/events/random")
+def random_event():
+    """返回随机事件"""
+    style = request.args.get("style", "")
+
+    session_id = session.get("session_id", "default")
+    try:
+        if hasattr(current_app, "game_instances") and session_id in current_app.game_instances:
+            game = current_app.game_instances[session_id]["game"]
+            ns = getattr(game, "narrative_system", None)
+            if ns:
+                event = ns.generate_story_event({"style": style})
+                return jsonify(event)
+    except Exception as e:  # pragma: no cover - fallback
+        current_app.logger.error(f"random_event error: {e}")
+
+    from src.xwe.features.narrative_system import narrative_system
+    event = narrative_system.generate_story_event({"style": style})
+    return jsonify(event)
 
 
 __all__ = ["events_bp"]

--- a/src/web/templates/components/event_modal.html
+++ b/src/web/templates/components/event_modal.html
@@ -1,0 +1,79 @@
+<!-- 随机事件模态框 -->
+<div id="eventModal" class="event-modal" style="display:none;">
+    <div class="event-content">
+        <h3 id="eventTitle">事件</h3>
+        <p id="eventDescription"></p>
+        <div id="eventChoices" class="event-choices"></div>
+    </div>
+</div>
+
+<style>
+.event-modal {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.8);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    z-index: 6000;
+}
+
+.event-content {
+    background: #1a1a2e;
+    padding: 20px;
+    border-radius: 8px;
+    color: #e0e0e0;
+    width: 300px;
+    text-align: center;
+}
+
+.event-choices button {
+    margin: 5px;
+    padding: 6px 12px;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+}
+</style>
+
+<script>
+const EventModal = {
+    async requestRandom(style = '') {
+        try {
+            const resp = await fetch(`/api/events/random?style=${encodeURIComponent(style)}`);
+            if (!resp.ok) throw new Error('network');
+            const data = await resp.json();
+            this.show(data);
+        } catch (e) {
+            console.error('获取随机事件失败', e);
+        }
+    },
+    show(eventData) {
+        const modal = document.getElementById('eventModal');
+        if (!modal) return;
+        document.getElementById('eventTitle').textContent = eventData.name || eventData.title || '事件';
+        document.getElementById('eventDescription').textContent = eventData.description || '';
+        const choices = document.getElementById('eventChoices');
+        choices.innerHTML = '';
+        (eventData.choices || []).forEach(choice => {
+            const btn = document.createElement('button');
+            btn.textContent = choice;
+            btn.onclick = () => this.handleChoice(choice, eventData);
+            choices.appendChild(btn);
+        });
+        modal.style.display = 'flex';
+    },
+    hide() {
+        const modal = document.getElementById('eventModal');
+        if (modal) modal.style.display = 'none';
+    },
+    handleChoice(choice, eventData) {
+        console.log('选择了', choice, eventData);
+        this.hide();
+    }
+};
+window.EventModal = EventModal;
+</script>

--- a/src/web/templates/components/sidebar_v2.html
+++ b/src/web/templates/components/sidebar_v2.html
@@ -18,6 +18,7 @@
                 <li><a href="#" onclick="GamePanels.showMap(); return false;">地图</a></li>
                 <li><a href="#" onclick="GamePanels.showQuests(); return false;">任务</a></li>
                 <li><a href="#" onclick="GamePanels.showIntel(); return false;">情报</a></li>
+                <li><a href="#" onclick="EventModal.requestRandom(); return false;">🎲 随机事件</a></li>
             </ul>
         </div>
         

--- a/src/web/templates/game_enhanced_optimized_v2.html
+++ b/src/web/templates/game_enhanced_optimized_v2.html
@@ -19,6 +19,7 @@
     {% include "components/welcome_modal_v2.html" %}
     {% include "components/world_intro.html" %}
     {% include "components/lore_modal.html" %}
+    {% include "components/event_modal.html" %}
 </div>
 {% endblock %}
 

--- a/src/web/templates/used_templates.txt
+++ b/src/web/templates/used_templates.txt
@@ -110,3 +110,4 @@ components/welcome_modal.html
 components/welcome_modal_v2.html
 components/roll_modal.html
 components/world_intro.html
+components/event_modal.html


### PR DESCRIPTION
## Summary
- add `/api/events/random` endpoint utilizing `generate_story_event`
- add EventModal component and hook to sidebar
- list EventModal in used templates
- include EventModal in main game page

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6869dd120004832893fc0815c744b855