### PR TITLE
Implement tool routing for NLP commands

### DIFF
--- a/src/xwe/core/nlp/__init__.py
+++ b/src/xwe/core/nlp/__init__.py
@@ -7,6 +7,7 @@ from .llm_client import LLMClient
 from .nlp_processor import NLPProcessor, DeepSeekNLPProcessor, ParsedCommand
 from .config import NLPConfig, get_nlp_config, reset_nlp_config
 from .monitor import NLPMonitor, get_nlp_monitor, reset_nlp_monitor
+from . import tool_router
 
 __all__ = [
     'LLMClient',
@@ -18,5 +19,6 @@ __all__ = [
     'reset_nlp_config',
     'NLPMonitor',
     'get_nlp_monitor',
-    'reset_nlp_monitor'
+    'reset_nlp_monitor',
+    'tool_router'
 ]

--- a/src/xwe/core/nlp/nlp_processor.py
+++ b/src/xwe/core/nlp/nlp_processor.py
@@ -14,6 +14,7 @@ from functools import lru_cache
 from .llm_client import LLMClient
 from .config import get_nlp_config
 from .monitor import get_nlp_monitor
+from . import tool_router
 
 # 专用日志记录器
 logger = logging.getLogger("xwe.nlp")
@@ -678,6 +679,8 @@ class NLPProcessor:
         """解析命令（新增方法）"""
         if self.enabled and self.processor:
             parsed = self.processor.parse(text)
+            # 在成功解析后分派到工具
+            tool_router.dispatch(parsed.normalized_command, parsed.args)
             return asdict(parsed)
         else:
             # 简单的本地解析

--- a/src/xwe/core/nlp/tool_router.py
+++ b/src/xwe/core/nlp/tool_router.py
@@ -1,0 +1,63 @@
+from typing import Any, Callable, Dict
+
+# Registered tools mapping
+_TOOL_REGISTRY: Dict[str, Callable[[Dict[str, Any]], Any]] = {}
+
+
+def register_tool(name: str) -> Callable[[Callable[[Dict[str, Any]], Any]], Callable[[Dict[str, Any]], Any]]:
+    """Decorator to register a function as a tool."""
+
+    def decorator(func: Callable[[Dict[str, Any]], Any]) -> Callable[[Dict[str, Any]], Any]:
+        _TOOL_REGISTRY[name] = func
+        return func
+
+    return decorator
+
+
+def dispatch(tool_name: str, payload: Dict[str, Any]) -> Any:
+    """Dispatch a call to a registered tool.
+
+    Args:
+        tool_name: Name of the tool to invoke.
+        payload: Parameters for the tool.
+
+    Returns:
+        The return value of the tool function.
+
+    Raises:
+        ValueError: If the tool is not registered.
+    """
+    if tool_name not in _TOOL_REGISTRY:
+        raise ValueError(f"Invalid tool: {tool_name}")
+    return _TOOL_REGISTRY[tool_name](payload)
+
+
+@register_tool("start_cultivation")
+def start_cultivation(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Placeholder start_cultivation tool."""
+    return {"action": "start_cultivation", "payload": payload}
+
+
+@register_tool("consume_pill")
+def consume_pill(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Placeholder consume_pill tool."""
+    return {"action": "consume_pill", "payload": payload}
+
+
+@register_tool("arrange_formation")
+def arrange_formation(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Placeholder arrange_formation tool."""
+    return {"action": "arrange_formation", "payload": payload}
+
+
+@register_tool("ask_player")
+def ask_player(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Placeholder ask_player tool."""
+    return {"action": "ask_player", "payload": payload}
+
+
+@register_tool("chat")
+def chat(payload: Dict[str, Any]) -> Dict[str, Any]:
+    """Placeholder chat tool."""
+    return {"action": "chat", "payload": payload}
+

--- a/tests/unit/test_tool_router.py
+++ b/tests/unit/test_tool_router.py
@@ -1,0 +1,56 @@
+import types
+import pytest
+
+from src.xwe.core.nlp import tool_router
+from src.xwe.core.nlp.nlp_processor import NLPProcessor, ParsedCommand
+
+
+def test_dispatch_valid_tool():
+    result = tool_router.dispatch("start_cultivation", {"hours": 1})
+    assert result["action"] == "start_cultivation"
+    assert result["payload"] == {"hours": 1}
+
+
+def test_dispatch_invalid_tool():
+    with pytest.raises(ValueError):
+        tool_router.dispatch("invalid_tool", {})
+
+
+def test_parse_command_triggers_dispatch(monkeypatch):
+    processor = NLPProcessor()
+    processor.enabled = True
+    parsed = ParsedCommand(
+        raw="修炼",
+        normalized_command="start_cultivation",
+        intent="action",
+        args={"hours": 2},
+        explanation="test",
+    )
+    monkeypatch.setattr(processor, "processor", types.SimpleNamespace(parse=lambda text: parsed))
+
+    called = {}
+
+    def fake_tool(payload):
+        called["payload"] = payload
+        return "ok"
+
+    monkeypatch.setitem(tool_router._TOOL_REGISTRY, "start_cultivation", fake_tool)
+
+    processor.parse_command("dummy")
+    assert called["payload"] == {"hours": 2}
+
+
+def test_parse_command_invalid_tool(monkeypatch):
+    processor = NLPProcessor()
+    processor.enabled = True
+    parsed = ParsedCommand(
+        raw="无效",
+        normalized_command="non_exist",
+        intent="action",
+        args={},
+        explanation="bad",
+    )
+    monkeypatch.setattr(processor, "processor", types.SimpleNamespace(parse=lambda text: parsed))
+
+    with pytest.raises(ValueError):
+        processor.parse_command("dummy")


### PR DESCRIPTION
## Summary
- add `tool_router` with a registry of callable tools
- expose `tool_router` from NLP package
- dispatch parsed commands through the new router
- test valid and invalid tool dispatch behaviour

## Testing
- `pytest tests/unit/test_tool_router.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6869e326ac988328951e179426b5979a