### PR TITLE
Add SSE updates for inventory

### DIFF
--- a/src/web/static/js/game_controller.js
+++ b/src/web/static/js/game_controller.js
@@ -454,6 +454,15 @@ class XianxiaGameController {
                 if (data.player && this.modules.profile) {
                     this.modules.profile.updateProfile(data.player);
                 }
+
+                if (data.inventory) {
+                    const gold = data.inventory.gold || 0;
+                    const goldElem = document.getElementById('status-gold');
+                    if (goldElem) goldElem.textContent = gold;
+                    if (window.GamePanels && typeof GamePanels.loadInventoryData === 'function') {
+                        GamePanels.loadInventoryData();
+                    }
+                }
             } catch (e) {
                 console.error('事件流解析失败:', e);
             }


### PR DESCRIPTION
## Summary
- broadcast inventory updates using status cache on add/remove
- update front-end event handler to refresh gold and inventory list

## Testing
- `pytest tests/e2e/optimizations/test_optimization_integration.py::TestOptimizationIntegration::test_mock_mode_end_to_end -v`
- `pytest tests/test_sidebar_api_restoration.py::test_achievements_with_achievement_manager -v`

------
https://chatgpt.com/codex/tasks/task_e_6869e491151c83288fade708a75b4262