### PR TITLE
Add style-aware event generation

### DIFF
--- a/src/api/routes/events.py
+++ b/src/api/routes/events.py
@@ -42,13 +42,13 @@ def random_event():
             game = current_app.game_instances[session_id]["game"]
             ns = getattr(game, "narrative_system", None)
             if ns:
-                event = ns.generate_story_event({"style": style})
+                event = ns.generate_story_event({}, player_style=style)
                 return jsonify(event)
     except Exception as e:  # pragma: no cover - fallback
         current_app.logger.error(f"random_event error: {e}")
 
     from src.xwe.features.narrative_system import narrative_system
-    event = narrative_system.generate_story_event({"style": style})
+    event = narrative_system.generate_story_event({}, player_style=style)
     return jsonify(event)
 
 

--- a/tests/unit/test_story_event_generation.py
+++ b/tests/unit/test_story_event_generation.py
@@ -1,0 +1,26 @@
+import random
+import pytest
+from src.xwe.features.narrative_system import NarrativeSystem
+
+
+def choose_highest(events, weights):
+    idx = weights.index(max(weights))
+    return [events[idx]]
+
+
+def test_generate_event_by_style(monkeypatch):
+    ns = NarrativeSystem()
+    monkeypatch.setattr(random, "choices", choose_highest)
+    aggressive = ns.generate_story_event({}, player_style="aggressive")
+    curious = ns.generate_story_event({}, player_style="curious")
+    assert aggressive["id"] == "demon_attack"
+    assert curious["id"] == "ancient_ruins"
+
+
+def test_generate_event_environment(monkeypatch):
+    ns = NarrativeSystem()
+    monkeypatch.setattr(random, "choices", choose_highest)
+    env = {"lingqi": 8, "comprehension": 3}
+    event = ns.generate_story_event({}, player_style="aggressive", environment=env)
+    assert "灵气充沛" in event["description"]
+    assert "悟性受到压制" in event["description"]


### PR DESCRIPTION
## Summary
- enrich `NarrativeSystem.generate_story_event` with `player_style` and `environment`
- introduce event template library with weights by style
- adjust `events` API to pass style param
- cover new behaviour with unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6869ea86ff74832899c80fafffc72d71