### PR TITLE
Fix broken redirect to game screen

### DIFF
--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -229,7 +229,7 @@ main_bp = Blueprint("main", __name__)
 @main_bp.route("/")
 def index():
     if session.get("player_created"):
-        return redirect(url_for("game_screen"))
+        return redirect(url_for("main.game_screen"))
     return redirect(url_for("intro_screen"))
 
 

--- a/src/web/templates/intro_optimized.html
+++ b/src/web/templates/intro_optimized.html
@@ -193,7 +193,7 @@
                     console.log('世界介绍完成，进入游戏主界面');
                     
                     // 跳转到游戏主界面
-                    window.location.href = "{{ url_for('game_screen') }}" + (this.devMode ? '?mode=dev' : '');
+                    window.location.href = "{{ url_for('main.game_screen') }}" + (this.devMode ? '?mode=dev' : '');
                 });
             }
         };
@@ -224,7 +224,7 @@
                 // Ctrl+Shift+G 直接进入游戏
                 if (e.ctrlKey && e.shiftKey && e.key === 'G') {
                     console.log('开发模式：直接进入游戏');
-                    window.location.href = "{{ url_for('game_screen', mode='dev') }}";
+                    window.location.href = "{{ url_for('main.game_screen', mode='dev') }}";
                 }
             });
         }


### PR DESCRIPTION
## Summary
- fix game screen redirection with blueprint prefix
- update intro page links to use blueprint endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686a3a8e1e988328bb6e7974d8269f70