### PR TITLE
Implement auto browser launch

### DIFF
--- a/run.py
+++ b/run.py
@@ -4,6 +4,9 @@
 """
 import sys
 from pathlib import Path
+import threading
+import webbrowser
+from time import sleep
 
 # 确保项目根目录在Python路径中
 PROJECT_ROOT = Path(__file__).resolve().parent
@@ -27,6 +30,7 @@ def main() -> None:
     parser.add_argument("--host", default="127.0.0.1", help="监听地址")
     parser.add_argument("--port", type=int, default=5001, help="端口")
     parser.add_argument("--debug", action="store_true", help="启用调试模式")
+    parser.add_argument("--no-browser", action="store_true", help="启动后不自动打开浏览器")
     args = parser.parse_args()
 
     # 配置目录
@@ -40,6 +44,18 @@ def main() -> None:
 
     # 创建并运行应用
     app = create_app()
+
+    url = f"http://{args.host}:{args.port}/"
+    if args.no_browser:
+        print(f"🖥️  请手动打开 {url}")
+    else:
+        def _open():
+            sleep(1.5)
+            webbrowser.open(url)
+
+        threading.Thread(target=_open, daemon=True).start()
+        print(f"🌐  已在浏览器打开 {url}")
+
     app.run(host=args.host, port=args.port, debug=args.debug)
 
 

--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -228,18 +228,13 @@ main_bp = Blueprint("main", __name__)
 
 @main_bp.route("/")
 def index():
-    if session.get("player_created"):
-        return redirect(url_for("main.game_screen"))
-
-    return redirect(url_for("main.intro_screen"))
-
-    return redirect(url_for("intro_screen"))
+    return redirect(url_for(".game_screen"))
 
 
 @main_bp.route("/welcome")
 def welcome():
     cleanup_old_instances()
-    return redirect(url_for("main.intro_screen"))
+    return redirect(url_for(".game_screen"))
 
 
 @main_bp.route("/intro")
@@ -250,10 +245,7 @@ def intro_screen():
 
 @main_bp.route("/start")
 def start_screen():
-    dev_mode = request.args.get("mode") == "dev"
-    if dev_mode:
-        return redirect(url_for("main.intro_screen", mode="dev"))
-    return redirect(url_for("main.intro_screen"))
+    return redirect(url_for(".game_screen"))
 
 
 @main_bp.route("/game")

--- a/tests/manual/test_auto_browser.py
+++ b/tests/manual/test_auto_browser.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Test automatic browser opening via ``run.py``."""
+
+import sys
+import importlib.util
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+SRC_PATH = PROJECT_ROOT / "src"
+if str(SRC_PATH) not in sys.path:
+    sys.path.insert(0, str(SRC_PATH))
+
+RUN_PATH = PROJECT_ROOT / "run.py"
+
+
+def _load_run_module():
+    spec = importlib.util.spec_from_file_location("run_script", RUN_PATH)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore
+    return module
+
+
+class DummyApp:
+    def run(self, host: str, port: int, debug: bool) -> None:  # pragma: no cover - dummy
+        self.host = host
+        self.port = port
+        self.debug = debug
+
+
+def test_open_browser(monkeypatch, capsys):
+    run = _load_run_module()
+    opened = []
+    monkeypatch.setattr(run, "create_app", lambda: DummyApp())
+    monkeypatch.setattr(run.threading, "Thread", lambda target, daemon=True: type("T", (), {"start": lambda self: target()})())
+    monkeypatch.setattr(run, "sleep", lambda s: None)
+    monkeypatch.setattr(run.webbrowser, "open", lambda url: opened.append(url))
+    monkeypatch.setattr(sys, "argv", ["run.py"])
+    run.main()
+    assert opened == ["http://127.0.0.1:5001/"]
+    captured = capsys.readouterr().out
+    assert "已在浏览器打开" in captured
+
+
+def test_no_browser_option(monkeypatch, capsys):
+    run = _load_run_module()
+    opened = []
+    monkeypatch.setattr(run, "create_app", lambda: DummyApp())
+    monkeypatch.setattr(run.threading, "Thread", lambda target, daemon=True: type("T", (), {"start": lambda self: target()})())
+    monkeypatch.setattr(run, "sleep", lambda s: None)
+    monkeypatch.setattr(run.webbrowser, "open", lambda url: opened.append(url))
+    monkeypatch.setattr(sys, "argv", ["run.py", "--no-browser"])
+    run.main()
+    assert opened == []
+    captured = capsys.readouterr().out
+    assert "请手动打开" in captured


### PR DESCRIPTION
## Summary
- auto-open browser on startup unless `--no-browser` is passed
- use blueprint-relative endpoint for root routes to jump directly into the game
- add tests for automatic browser behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_686b869d58448328b8155375d266a99f