### PR TITLE
Remove banner from smart_start

### DIFF
--- a/scripts/smart_start.py
+++ b/scripts/smart_start.py
@@ -11,11 +11,6 @@ from pathlib import Path
 PROJECT_ROOT = Path(__file__).resolve().parent
 sys.path.insert(0, str(PROJECT_ROOT))
 
-print("""
-╔════════════════════════════════════════╗
-║        修仙世界引擎 - 智能启动器       ║
-╚════════════════════════════════════════╝
-""")
 
 # 1. 设置环境变量
 print("1. 配置环境...")


### PR DESCRIPTION
## Summary
- remove banner print in `smart_start.py`

## Testing
- `python scripts/smart_start.py` *(fails: ModuleNotFoundError: No module named 'src')*


------
https://chatgpt.com/codex/tasks/task_e_686bb85f63048328906177cdbe4aa581