### PR TITLE
Fix measure_performance context manager

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -32,6 +32,7 @@ markers =
     integration: 集成测试
     unit: 单元测试
     e2e: 端到端测试
+    asyncio: 异步测试
 
 # 输出选项
 addopts = 

--- a/src/xwe/core/context/compressor.py
+++ b/src/xwe/core/context/compressor.py
@@ -11,7 +11,10 @@ import json
 
 from .memory_block import MemoryBlock
 from .summarizer import ContextSummarizer
-from ..nlp.llm_client import LLMClient
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..nlp.llm_client import LLMClient
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +31,7 @@ class ContextCompressor:
     """
     
     def __init__(self,
-                 llm_client: Optional[LLMClient] = None,
+                 llm_client: Optional["LLMClient"] = None,
                  window_size: int = 20,
                  block_size: int = 30,
                  max_memory_blocks: int = 10,
@@ -43,6 +46,10 @@ class ContextCompressor:
             max_memory_blocks: 最大记忆块数量
             enable_compression: 是否启用压缩（用于测试）
         """
+        if llm_client is None:
+            from ..nlp.llm_client import LLMClient
+            llm_client = LLMClient()
+
         self.window_size = window_size
         self.block_size = block_size
         self.max_memory_blocks = max_memory_blocks
@@ -70,6 +77,12 @@ class ContextCompressor:
             f"window={window_size}, block={block_size}, "
             f"max_blocks={max_memory_blocks}"
         )
+
+    def compress(self, messages: List[Dict[str, Any]]) -> str:
+        """一次性压缩给定的消息列表并返回摘要"""
+
+        contents = [m.get("content", "") for m in messages]
+        return self.summarizer.summarize(contents, structured=False)
     
     def append(self, message: str) -> None:
         """

--- a/src/xwe/core/context/summarizer.py
+++ b/src/xwe/core/context/summarizer.py
@@ -7,7 +7,10 @@ import json
 import logging
 from typing import List, Optional, Dict, Any
 
-from ..nlp.llm_client import LLMClient
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..nlp.llm_client import LLMClient
 
 logger = logging.getLogger(__name__)
 
@@ -17,13 +20,17 @@ class ContextSummarizer:
     上下文摘要器 - 使用 LLM 生成简洁的对话摘要
     """
     
-    def __init__(self, llm_client: Optional[LLMClient] = None):
+    def __init__(self, llm_client: Optional["LLMClient"] = None):
         """
         初始化摘要器
         
         Args:
             llm_client: LLM 客户端实例，如果不提供则创建新实例
         """
+        if llm_client is None:
+            from ..nlp.llm_client import LLMClient
+            llm_client = LLMClient()
+
         self.llm_client = llm_client
         self._init_prompts()
         

--- a/tests/benchmark/test_nlp_performance.py
+++ b/tests/benchmark/test_nlp_performance.py
@@ -31,25 +31,28 @@ os.environ['ENABLE_PROMETHEUS'] = 'true'
 def measure_performance():
     """性能测量上下文管理器"""
     process = psutil.Process()
-    
+
     # 开始测量
     start_time = time.time()
     start_cpu = process.cpu_percent()
     start_memory = process.memory_info().rss / 1024 / 1024  # MB
-    
-    yield
-    
-    # 结束测量
-    end_time = time.time()
-    end_cpu = process.cpu_percent()
-    end_memory = process.memory_info().rss / 1024 / 1024  # MB
-    
-    return {
-        'duration': end_time - start_time,
-        'cpu_usage': end_cpu - start_cpu,
-        'memory_delta': end_memory - start_memory,
-        'final_memory': end_memory
-    }
+
+    metrics: Dict[str, Any] = {}
+
+    try:
+        yield metrics
+    finally:
+        # 结束测量
+        end_time = time.time()
+        end_cpu = process.cpu_percent()
+        end_memory = process.memory_info().rss / 1024 / 1024  # MB
+
+        metrics.update({
+            'duration': end_time - start_time,
+            'cpu_usage': end_cpu - start_cpu,
+            'memory_delta': end_memory - start_memory,
+            'final_memory': end_memory
+        })
 
 
 class TestNLPPerformance:
@@ -64,7 +67,7 @@ class TestNLPPerformance:
     @pytest.fixture
     def context_compressor(self):
         """创建上下文压缩器"""
-        from xwe.core.context.context_compressor import ContextCompressor
+        from xwe.core.context import ContextCompressor
         return ContextCompressor()
     
     def test_context_compression_ratio(self, context_compressor):


### PR DESCRIPTION
## Summary
- update `measure_performance` so that it yields a metrics dict
- declare asyncio marker in pytest config
- fix ContextCompressor import and avoid circular dependency
- add simple `compress` method to ContextCompressor

## Testing
- `pytest tests/benchmark/test_nlp_performance.py::TestNLPPerformance::test_context_compression_ratio -q`


------
https://chatgpt.com/codex/tasks/task_e_686c64666b108328a27ce780a31a5d93