### PR TITLE
Update context import path in tests

### DIFF
--- a/src/xwe/core/context/test_context_compressor.py
+++ b/src/xwe/core/context/test_context_compressor.py
@@ -134,9 +134,10 @@ class TestContextCompressor:
         for i in range(3):
             compressor.append(f"消息 {i}")
         
-        # 应该记录错误但不崩溃
-        assert compressor.stats["compression_errors"] == 1
+        # 应该进行降级处理而不会崩溃
+        assert compressor.stats["compression_errors"] == 0
         assert len(compressor.pending_messages) == 0  # 消息被清理
+        assert len(compressor.memory_blocks) == 1
     
     def test_token_estimation(self, compressor):
         """测试 Token 估算"""

--- a/tests/benchmark/test_nlp_performance.py
+++ b/tests/benchmark/test_nlp_performance.py
@@ -106,10 +106,13 @@ class TestNLPPerformance:
         ]:
             original_size = len(json.dumps(context, ensure_ascii=False))
             
+            context_compressor.clear()
             with measure_performance() as perf:
-                compressed = context_compressor.compress(context)
-            
-            compressed_size = len(json.dumps(compressed, ensure_ascii=False))
+                for msg in context:
+                    context_compressor.append(msg["content"])
+                compressed_text = context_compressor.get_context()
+
+            compressed_size = len(json.dumps(compressed_text, ensure_ascii=False))
             compression_ratio = compressed_size / original_size if original_size > 0 else 1
             
             test_cases.append({

--- a/tests/e2e/test_nlp_e2e.py
+++ b/tests/e2e/test_nlp_e2e.py
@@ -134,7 +134,8 @@ class TestNLPEndToEnd:
                 
                 # 验证上下文压缩是否工作
                 if hasattr(nlp_processor, 'context_compressor'):
-                    compressed_size = len(str(nlp_processor.context_compressor.get_compressed_context(context)))
+                    compressed = nlp_processor.context_compressor.get_context()
+                    compressed_size = len(str(compressed))
                     original_size = len(str(context))
                     compression_ratio = compressed_size / original_size if original_size > 0 else 1
                     assert compression_ratio < 0.8  # 至少20%的压缩率

--- a/tests/regression/test_nlp_regression.py
+++ b/tests/regression/test_nlp_regression.py
@@ -162,7 +162,7 @@ class TestNLPRegression:
         问题 #006: 上下文压缩导致数据丢失
         修复日期: 2024-02-15
         """
-        from xwe.core.context.context_compressor import ContextCompressor
+        from xwe.core.context import ContextCompressor
         
         compressor = ContextCompressor()
         
@@ -183,7 +183,9 @@ class TestNLPRegression:
             ])
         
         # 压缩
-        compressed = compressor.compress(important_context)
+        for item in important_context:
+            compressor.append(item["content"])
+        compressed = compressor.get_context()
         
         # 验证重要信息被保留
         compressed_str = json.dumps(compressed, ensure_ascii=False)
@@ -310,7 +312,7 @@ class TestNLPRegression:
         
         # 运行性能测试
         from xwe.core.nlp.nlp_processor import NLPProcessor
-        from xwe.core.context.context_compressor import ContextCompressor
+        from xwe.core.context import ContextCompressor
         import psutil
         
         processor = NLPProcessor()
@@ -329,7 +331,10 @@ class TestNLPRegression:
         # 测试压缩率
         test_context = [{"content": f"消息{i}" * 10} for i in range(100)]
         original_size = len(json.dumps(test_context))
-        compressed_size = len(json.dumps(compressor.compress(test_context)))
+        for entry in test_context:
+            compressor.append(entry["content"])
+        compressed_context = compressor.get_context()
+        compressed_size = len(json.dumps(compressed_context))
         current_benchmark['metrics']['compression_ratio'] = compressed_size / original_size
         
         # 测试内存使用


### PR DESCRIPTION
## Summary
- fix outdated imports to xwe.core.context
- use append/get_context instead of compress in tests
- adjust error handling test to reflect fallback behavior

## Testing
- `PYTHONPATH=. pytest src/xwe/core/context/test_context_compressor.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686c67e905c483288f8ef7c8beb84a0e