### PR TITLE
Add profiling utilities for tests

### DIFF
--- a/tests/utils/__init__.py
+++ b/tests/utils/__init__.py
@@ -1,0 +1,16 @@
+"""测试工具包
+
+提供常用的测试辅助函数和性能/内存分析工具。"""
+
+from . import memory_profiler, performance_profiler, test_fixtures, test_helpers
+from .memory_profiler import *  # noqa: F401,F403
+from .performance_profiler import *  # noqa: F401,F403
+from .test_fixtures import *  # noqa: F401,F403
+from .test_helpers import *  # noqa: F401,F403
+
+__all__ = (
+    test_helpers.__all__
+    + test_fixtures.__all__
+    + performance_profiler.__all__
+    + memory_profiler.__all__
+)

--- a/tests/utils/memory_profiler.py
+++ b/tests/utils/memory_profiler.py
@@ -1,0 +1,63 @@
+"""内存分析工具
+
+提供基本的内存使用统计函数，供测试模块使用。
+"""
+
+import time
+from contextlib import contextmanager
+from typing import Any, Callable, Dict
+
+import psutil
+
+
+@contextmanager
+def memory_usage_tracker() -> None:
+    """上下文管理器：追踪代码块的内存变化(MB)。"""
+    process = psutil.Process()
+    start_mem = process.memory_info().rss
+    start_time = time.time()
+    try:
+        yield
+    finally:
+        end_mem = process.memory_info().rss
+        end_time = time.time()
+        delta_mb = (end_mem - start_mem) / 1024 / 1024
+        duration = end_time - start_time
+        print(f"Memory change: {delta_mb:.4f} MB, duration: {duration:.4f}s")
+
+
+def profile_memory(func: Callable, *args: Any, **kwargs: Any) -> Dict[str, float]:
+    """执行函数并返回内存变化（MB）和持续时间。"""
+    process = psutil.Process()
+    start_mem = process.memory_info().rss
+    start_time = time.time()
+    result = func(*args, **kwargs)
+    end_time = time.time()
+    end_mem = process.memory_info().rss
+
+    return {
+        "result": result,
+        "memory_change_mb": (end_mem - start_mem) / 1024 / 1024,
+        "duration": end_time - start_time,
+    }
+
+
+__all__ = ["memory_usage_tracker", "profile_memory"]
+
+
+def _busy_work() -> int:
+    """Simple workload used in tests."""
+    return sum(i * i for i in range(1000))
+
+
+def test_profile_memory() -> None:
+    """profile_memory 应该返回统计信息并保持结果正确。"""
+    stats = profile_memory(_busy_work)
+    assert stats["result"] == _busy_work()
+    assert stats["duration"] >= 0
+
+
+def test_memory_usage_tracker() -> None:
+    """memory_usage_tracker 上下文应正常运行。"""
+    with memory_usage_tracker():
+        _busy_work()

--- a/tests/utils/performance_profiler.py
+++ b/tests/utils/performance_profiler.py
@@ -1,0 +1,67 @@
+"""性能分析工具
+
+提供基本的 CPU 使用率统计函数，供测试模块使用。
+"""
+
+import time
+from contextlib import contextmanager
+from typing import Any, Callable, Dict
+
+import psutil
+
+
+@contextmanager
+def cpu_usage_tracker() -> None:
+    """上下文管理器：追踪代码块的 CPU 使用时间。"""
+    process = psutil.Process()
+    start_times = process.cpu_times()
+    start_time = time.time()
+    try:
+        yield
+    finally:
+        end_times = process.cpu_times()
+        end_time = time.time()
+        user_time = end_times.user - start_times.user
+        system_time = end_times.system - start_times.system
+        duration = end_time - start_time
+        print(
+            f"CPU user: {user_time:.4f}s, system: {system_time:.4f}s, duration: {duration:.4f}s"
+        )
+
+
+def profile_cpu(func: Callable, *args: Any, **kwargs: Any) -> Dict[str, float]:
+    """执行函数并返回 CPU 使用时间和持续时间。"""
+    process = psutil.Process()
+    start_times = process.cpu_times()
+    start_time = time.time()
+    result = func(*args, **kwargs)
+    end_time = time.time()
+    end_times = process.cpu_times()
+
+    return {
+        "result": result,
+        "user_time": end_times.user - start_times.user,
+        "system_time": end_times.system - start_times.system,
+        "duration": end_time - start_time,
+    }
+
+
+__all__ = ["cpu_usage_tracker", "profile_cpu"]
+
+
+def _busy_work() -> int:
+    """Simple workload used in tests."""
+    return sum(i * i for i in range(1000))
+
+
+def test_profile_cpu() -> None:
+    """profile_cpu 应该返回统计信息并保持结果正确。"""
+    stats = profile_cpu(_busy_work)
+    assert stats["result"] == _busy_work()
+    assert stats["duration"] >= 0
+
+
+def test_cpu_usage_tracker() -> None:
+    """cpu_usage_tracker 上下文应正常运行。"""
+    with cpu_usage_tracker():
+        _busy_work()


### PR DESCRIPTION
## Summary
- add CPU profiling helper
- add memory profiling helper
- expose profiling utilities via tests/utils package
- add simple tests to profiling utilities

## Testing
- `pre-commit run --files tests/utils/performance_profiler.py tests/utils/memory_profiler.py tests/utils/__init__.py`
- `pytest tests/utils/performance_profiler.py tests/utils/memory_profiler.py -q`

------
https://chatgpt.com/codex/tasks/task_e_686c6b68ab488328b1a5d2f55393cbf4