### PR TITLE
Add pandas/matplotlib to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -36,5 +36,9 @@ playwright==1.42.0
 # 监控和指标
 prometheus-flask-exporter==0.23.0
 
+# 数据分析与绘图（测试使用）
+pandas==2.0.3
+matplotlib==3.7.5
+
 # 注意：DeepSeek SDK 需要单独安装
 # pip install deepseek

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -32,6 +32,10 @@ def main():
 
     all_passed = True
 
+    # 安装依赖
+    if not run_command("pip install -r requirements.txt", "安装Python依赖"):
+        return 1
+
     # 1. 检查导入
     if os.path.exists("check_imports.py"):
         if not run_command("python check_imports.py", "检查模块导入"):
@@ -45,9 +49,7 @@ def main():
         "yes",
     }
     if not skip_pw_install:
-        if not run_command(
-            "npx playwright install --with-deps", "安装 Playwright 浏览器依赖"
-        ):
+        if not run_command("npx playwright install --with-deps", "安装 Playwright 浏览器依赖"):
             print("\n⚠️  Playwright 安装失败，继续执行测试")
     else:
         print("跳过 Playwright 安装步骤")


### PR DESCRIPTION
## Summary
- add pandas and matplotlib to requirements for benchmark tests
- ensure run_tests.py installs dependencies before running

## Testing
- `pre-commit run --files requirements.txt scripts/run_tests.py` *(with SKIP=pytest)*

------
https://chatgpt.com/codex/tasks/task_e_686ce71a30948328934919a552a84888