### PR TITLE
标记并跳过耗时测试

### DIFF
--- a/tests/benchmark/test_nlp_performance.py
+++ b/tests/benchmark/test_nlp_performance.py
@@ -55,6 +55,7 @@ def measure_performance():
         })
 
 
+@pytest.mark.slow
 class TestNLPPerformance:
     """NLP 性能基准测试"""
     

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,24 @@ import pytest
 from dotenv import load_dotenv
 from flask import Flask
 
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--runslow",
+        action="store_true",
+        default=False,
+        help="运行被标记为 slow 的测试",
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runslow"):
+        return
+    skip_slow = pytest.mark.skip(reason="需要 --runslow 才能运行慢速测试")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)
+
 load_dotenv()
 
 # Ensure the src directory is in sys.path so modules can find 'config' and others

--- a/tests/e2e/test_nlp_e2e.py
+++ b/tests/e2e/test_nlp_e2e.py
@@ -93,6 +93,7 @@ class TestNLPEndToEnd:
             data = response.get_json()
             assert 'success' in data or 'result' in data
     
+    @pytest.mark.slow
     def test_long_conversation(self, nlp_processor):
         """测试长对话（100+ 轮）"""
         conversation_rounds = 120
@@ -140,6 +141,7 @@ class TestNLPEndToEnd:
                     compression_ratio = compressed_size / original_size if original_size > 0 else 1
                     assert compression_ratio < 0.8  # 至少20%的压缩率
     
+    @pytest.mark.slow
     def test_concurrent_users(self, app):
         """测试并发用户（10+ 并发）"""
         from xwe.core.nlp.nlp_processor import NLPProcessor
@@ -278,6 +280,7 @@ class TestNLPEndToEnd:
             # 应该优雅处理内存错误
             pass
     
+    @pytest.mark.slow
     def test_memory_leak_detection(self, nlp_processor):
         """内存泄漏检测"""
         # 启动内存追踪

--- a/tests/stress/test_nlp_stress.py
+++ b/tests/stress/test_nlp_stress.py
@@ -88,6 +88,7 @@ class StressTestMetrics:
         return error_types
 
 
+@pytest.mark.slow
 class TestNLPStress:
     """NLP 压力测试"""
     


### PR DESCRIPTION
## 总结
- 在压力测试、性能基准测试以及部分 E2E 测试中加入 `@pytest.mark.slow`
- 在 `tests/conftest.py` 中新增 `--runslow` 参数，默认跳过慢速测试
- 通过 `--runslow` 可显式运行这些测试

## Testing
- `pytest -k test_long_conversation -vv` （默认跳过慢速测试）
- `pytest -k test_long_conversation -vv --runslow` （尝试运行慢速测试，出现依赖错误）

------
https://chatgpt.com/codex/tasks/task_e_686ce9edfa988328928f7326300a7a9e