### PR TITLE
Add async helpers and metrics registry

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -42,3 +42,4 @@ matplotlib==3.7.5
 
 # 注意：DeepSeek SDK 需要单独安装
 # pip install deepseek
+objgraph==3.6.2

--- a/src/xwe/core/context/context_compressor.py
+++ b/src/xwe/core/context/context_compressor.py
@@ -1,0 +1,3 @@
+from .compressor import ContextCompressor
+
+__all__ = ["ContextCompressor"]


### PR DESCRIPTION
## Summary
- add missing `AsyncWrapper`, `AsyncBatchProcessor`, `AsyncRequestQueue` and `RateLimiter`
- expose `ContextCompressor` under expected path
- add custom Prometheus registry to avoid duplicate metrics
- include `objgraph` in dependencies
- extend `NLPProcessor` wrapper with context compression option, `llm_client` alias and `process` helper

## Testing
- `pytest tests/unit/test_async_utils.py::TestAsyncWrapper::test_basic_wrapping -q`
- `pytest tests/unit/test_nlp_processor.py::TestNLPProcessor::test_initialization -q`
- `pytest tests/unit/test_nlp_processor.py::TestNLPProcessor::test_empty_input_handling -q`
- `pytest tests/unit/test_nlp_processor.py::TestNLPProcessor::test_llm_integration -q`
- `pytest tests/unit/test_nlp_processor.py::TestErrorHandling::test_malformed_input_recovery -q`
- `pytest -q` *(fails: context compressor and sidebar API tests)*

------
https://chatgpt.com/codex/tasks/task_e_686d0812a5588328a137bf810f6f2fbe