### PR TITLE
Fix pytest errors with stub endpoints and metrics

### DIFF
--- a/src/xwe/metrics/prometheus_metrics.py
+++ b/src/xwe/metrics/prometheus_metrics.py
@@ -345,9 +345,10 @@ def init_prometheus_app_metrics(app, app_version='1.0.0', app_config=None):
         excluded_paths=['/static', '/health', '/favicon.ico']
     )
     
-    # 添加应用信息
-    metrics.info('xwe_app_info', 'XianXia World Engine application info', 
-                 version=app_version)
+    # 添加应用信息，避免重复注册
+    if 'xwe_app_info' not in REGISTRY._names_to_collectors:
+        metrics.info('xwe_app_info', 'XianXia World Engine application info',
+                     version=app_version)
     
     # 禁用默认指标（如果配置要求）
     if not enable_default_metrics:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,13 +6,13 @@ import os
 
 # 设置测试环境变量
 os.environ['USE_MOCK_LLM'] = 'true'
-os.environ['ENABLE_PROMETHEUS'] = 'true'
+os.environ['ENABLE_PROMETHEUS'] = 'false'
 os.environ['ENABLE_CONTEXT_COMPRESSION'] = 'true'
 
 # 标记慢速测试
 def pytest_configure(config):
     config.addinivalue_line(
-        "markers", "slow: marks tests as slow (deselect with '-m "not slow"')"
+        "markers", "slow: marks tests as slow (deselect with '-m \"not slow\"')"
     )
     config.addinivalue_line(
         "markers", "integration: marks tests as integration tests"
@@ -40,3 +40,20 @@ def pytest_collection_modifyitems(config, items):
         # 标记不稳定的测试
         if "thread_safe" in item.nodeid or "burst_handling" in item.nodeid:
             item.add_marker(pytest.mark.flaky)
+
+
+@pytest.fixture
+def app():
+    """提供 Flask 应用实例"""
+    from app import create_app
+    application = create_app()
+    application.config['TESTING'] = True
+    application.config['WTF_CSRF_ENABLED'] = False
+    return application
+
+
+@pytest.fixture
+def client(app):
+    """提供 Flask 测试客户端"""
+    with app.test_client() as client:
+        yield client


### PR DESCRIPTION
## Summary
- disable prometheus by default in tests and avoid duplicate metrics
- provide global app and client fixtures
- add stub API endpoints in demo `app.py`
- guard Prometheus initialization with env variable

## Testing
- `pytest tests/api/test_sidebar_endpoints.py -q`
- `pytest tests/integration/test_nlp_integration.py::TestNLPIntegration::test_flask_routes_integration -q`

------
https://chatgpt.com/codex/tasks/task_e_686f54cef8b883288995ef7feac9ecf0