### PR TITLE
Add DeepSeek async tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ python fix_dependencies.py
 
 ```bash
 python tests/run_tests.py all
+# 运行 DeepSeek 异步单元测试
+python scripts/run_async_tests.py
 ```
 
 ### 5. 启用异步模式（可选）

--- a/docs/DEEPSEEK_ASYNC_QUICKSTART.md
+++ b/docs/DEEPSEEK_ASYNC_QUICKSTART.md
@@ -25,8 +25,8 @@ export FLASK_ASYNC_ENABLED=1
 ### 3. 快速测试
 
 ```bash
-# 运行快速测试脚本
-python scripts/test_deepseek_async.py
+# 运行异步单元测试
+python scripts/run_async_tests.py
 ```
 
 ### 4. 启动服务

--- a/run_tests.py
+++ b/run_tests.py
@@ -27,6 +27,7 @@ TEST_GROUPS = {
         'tests/unit/test_async_utils.py::TestAsyncRequestQueue::test_blocking_operations',
         'tests/unit/test_async_utils.py::TestRateLimiter::test_burst_handling',
         'tests/unit/test_async_utils.py::TestRateLimiter::test_thread_safe',
+        'tests/unit/test_deepseek_async.py',
     ],
     'api': [
         'tests/regression/test_nlp_regression.py::TestNLPRegression::test_api_compatibility',

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -10,5 +10,8 @@ python -m pytest tests/unit/test_status.py -v
 echo -e "\n运行 NLP Processor 测试..."
 python -m pytest tests/unit/test_nlp_processor.py -v
 
+echo -e "\n运行 DeepSeek 异步客户端测试..."
+python scripts/run_async_tests.py
+
 echo -e "\n运行所有测试并统计..."
 python -m pytest tests/ -v --tb=short | tail -20


### PR DESCRIPTION
## Summary
- cover DeepSeek async client in `run_tests.sh`
- include `test_deepseek_async.py` in `run_tests.py`
- document how to run async tests in README
- update async quickstart guide

## Testing
- `python scripts/run_async_tests.py` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `python run_tests.py async` *(fails: ERROR tests/unit/test_deepseek_async.py)*
- `bash run_tests.sh` *(fails: 18 errors during collection)*


------
https://chatgpt.com/codex/tasks/task_e_6871977f3c848328a7a5ed0595b5e5da