### PR TITLE
chore: ignore generated fix reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,7 @@ yarn-error.log
 *validation_results.json
 *test_duration_bar.png
 *_REPORT.md
+*fix_report.json
+*validation_results.json
+*test_duration_bar.png
+*_REPORT.md


### PR DESCRIPTION
## Summary
- ignore generated fix report artifacts in `.gitignore`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6873861065dc8328b292e76f6e173138