### PR TITLE
Organize maintenance scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ python fix_dependencies.py
 然后执行：
 
 ```bash
-python tests/run_tests.py all
+python scripts/maintenance/run_tests.py all
 # 运行 DeepSeek 异步单元测试
 python scripts/run_async_tests.py
 ```


### PR DESCRIPTION
## Summary
- keep maintenance scripts together
- point README test command to maintenance script

## Testing
- `pytest -k 'nonexistenttest' -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68738b2d492c8328871d0dbd26659302