### PR TITLE
chore: deduplicate report entries in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,11 +62,3 @@ yarn-error.log
 *validation_results.json
 *test_duration_bar.png
 *_REPORT.md
-*fix_report.json
-*validation_results.json
-*test_duration_bar.png
-*_REPORT.md
-*fix_report.json
-*validation_results.json
-*test_duration_bar.png
-*_REPORT.md


### PR DESCRIPTION
## Summary
- clean up duplicated entries for generated report files in `.gitignore`

## Testing
- `make test-fast` *(fails: ModuleNotFoundError: No module named 'flask')*
- `pip install -r requirements.txt` *(fails: building wheels for pandas cancelled)*

------
https://chatgpt.com/codex/tasks/task_e_687c799dc2a08328bbce671167a03594