### PR TITLE
style: drop unused import in llm_client

### DIFF
--- a/src/xwe/core/nlp/llm_client.py
+++ b/src/xwe/core/nlp/llm_client.py
@@ -8,10 +8,9 @@ import functools
 import json
 import logging
 import os
-import re
 from concurrent.futures import ThreadPoolExecutor
 from time import sleep, time
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional
 
 try:
     import requests


### PR DESCRIPTION
## Summary
- clean up an unused import from `llm_client`

## Testing
- `ruff check src/xwe/core/nlp/llm_client.py`

------
https://chatgpt.com/codex/tasks/task_e_687ca75893c88328ad66511fc8b5e023