### PR TITLE
Always show landing page with dev toggle

### DIFF
--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -245,12 +245,15 @@ main_bp = Blueprint("main", __name__)
 
 @main_bp.route("/")
 def index():
-    if is_dev_request() or request.args.get("mode") == "dev":
-        # Developer mode entry uses the new templates introduced recently
-        return render_template("index.html")
+    """Landing page with optional developer entry."""
+    dev_mode = is_dev_request() or request.args.get("mode") == "dev"
+    return render_template("index.html", dev_mode=dev_mode)
 
-    # Default behaviour redirects to the standard game screen
-    return redirect(url_for(".game_screen"))
+
+@main_bp.route("/status")
+def status_page():
+    """Simple status page for health checks."""
+    return "ok", 200
 
 
 @main_bp.route("/welcome")

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -242,6 +242,9 @@
             <a href="/docs" class="btn">查看文档</a>
             <a href="https://github.com/xianxia-team/xianxia-world-engine" class="btn">GitHub</a>
             <a href="/api" class="btn">API测试</a>
+            {% if dev_mode %}
+            <a href="/game?mode=dev" class="btn">开发者入口</a>
+            {% endif %}
         </div>
         
         <footer>


### PR DESCRIPTION
## Summary
- always render `index.html` for the root route
- expose a simple `/status` endpoint for health checks
- show a developer entry on the landing page when `dev_mode` is enabled

## Testing
- `make test-fast` *(fails: 23 failed, 177 passed, 33 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_688214f9abe88328a124824209a7540b