### PR TITLE
Add continue route and settings modal

### DIFF
--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -273,6 +273,24 @@ def start_screen():
     return redirect(url_for(".game_screen"))
 
 
+@main_bp.route("/continue")
+def continue_game():
+    """Load autosave and enter the game."""
+    if "session_id" not in session:
+        session["session_id"] = str(time.time())
+
+    instance = get_game_instance(session["session_id"])
+    game = instance["game"]
+
+    if hasattr(game, "technical_ops"):
+        state = game.technical_ops.load_game("autosave")
+        if state:
+            game.game_state = state
+            instance["need_refresh"] = True
+
+    return redirect(url_for(".game_screen"))
+
+
 @main_bp.route("/game")
 def game_screen():
     if "session_id" not in session:

--- a/src/web/templates/components/header.html
+++ b/src/web/templates/components/header.html
@@ -18,6 +18,7 @@
             <i class="icon-star"></i>
             <span id="playerRealm">{{ player.attributes.realm_name|default('炼气期') }}</span>
         </span>
+        <button class="settings-btn" onclick="openModal('settings')">⚙️</button>
     </div>
 </header>
 
@@ -52,4 +53,11 @@
 .icon-location::before { content: '📍'; }
 .icon-user::before { content: '👤'; }
 .icon-star::before { content: '⭐'; }
+.settings-btn {
+    background: none;
+    border: none;
+    color: #e0e0e0;
+    cursor: pointer;
+    font-size: 18px;
+}
 </style>

--- a/src/web/templates/game_enhanced_optimized_v2.html
+++ b/src/web/templates/game_enhanced_optimized_v2.html
@@ -20,6 +20,10 @@
     {% include "components/world_intro.html" %}
     {% include "components/lore_modal.html" %}
     {% include "components/event_modal.html" %}
+    {% include "modals/settings.html" %}
+    <div id="modal" style="display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.6);overflow:auto;z-index:1000;">
+        <div id="modal-content" style="background:#222;margin:10% auto;padding:20px;border-radius:8px;max-width:600px;color:#ddd;"></div>
+    </div>
 </div>
 {% endblock %}
 
@@ -27,6 +31,22 @@
 <script src="{{ url_for('static', filename='js/game_main.js') }}"></script>
 <script src="{{ url_for('static', filename='js/game_panels_enhanced.js') }}"></script>
 <script>
+    async function openModal(name) {
+        const modal = document.getElementById('modal');
+        const content = document.getElementById('modal-content');
+        modal.style.display = 'block';
+        const resp = await fetch(`/modal/${name}`);
+        content.innerHTML = await resp.text();
+    }
+
+    function closeModal() {
+        document.getElementById('modal').style.display = 'none';
+    }
+
+    function continueGame() {
+        window.location.href = '/continue';
+    }
+
     window.onload = function() {
         GameUI.init(); // 初始化游戏 UI 功能（绑定日志、指令框、弹窗等）
         WelcomeSystem.show(); // 启动欢迎界面

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -237,11 +237,13 @@
 
         <div class="actions">
             <a href="/game" class="btn primary">开始游戏</a>
+            <a href="#" class="btn" onclick="continueGame(); return false;">继续游戏</a>
             <a href="/api/health" class="btn">健康检查</a>
             <a href="/metrics" class="btn">性能指标</a>
             <a href="/docs" class="btn">查看文档</a>
             <a href="https://github.com/xianxia-team/xianxia-world-engine" class="btn">GitHub</a>
             <a href="/api" class="btn">API测试</a>
+            <button class="btn" onclick="openModal('settings')">设置</button>
             {% if dev_mode %}
             <a href="/game?mode=dev" class="btn">开发者入口</a>
             {% endif %}
@@ -253,7 +255,30 @@
         </footer>
     </div>
 
+    <div id="modal" style="display:none;position:fixed;top:0;left:0;width:100%;height:100%;background:rgba(0,0,0,0.6);overflow:auto;z-index:1000;">
+        <div id="modal-content" style="background:#222;margin:10% auto;padding:20px;border-radius:8px;max-width:600px;color:#ddd;"></div>
+    </div>
+
+    {% include "modals/settings.html" %}
+
     <script>
+        // 打开模态框
+        async function openModal(name) {
+            const modal = document.getElementById('modal');
+            const content = document.getElementById('modal-content');
+            modal.style.display = 'block';
+            const resp = await fetch(`/modal/${name}`);
+            content.innerHTML = await resp.text();
+        }
+
+        function closeModal() {
+            document.getElementById('modal').style.display = 'none';
+        }
+
+        function continueGame() {
+            window.location.href = '/continue';
+        }
+
         // 获取健康状态
         async function fetchHealth() {
             try {


### PR DESCRIPTION
## Summary
- add `/continue` endpoint to load autosave before entering the game
- show settings modal from index and game pages
- expose `openModal` and `continueGame` front-end helpers
- add settings button to header

## Testing
- `pre-commit run --files src/app/__init__.py src/web/templates/components/header.html src/web/templates/game_enhanced_optimized_v2.html src/web/templates/index.html` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_688226de17208328a187b344e55f1d25