### PR TITLE
Add character reroll e2e test

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,6 +38,20 @@ lint:
     - black --check src/ tests/
     - isort --check-only src/ tests/
 
+e2e_playwright:
+  stage: test
+  image: mcr.microsoft.com/playwright/python:v1.53.1
+  script:
+    - pip install -r requirements.txt
+    - npm ci
+    - npx playwright install --with-deps
+    - npx playwright test tests/e2e/character_reroll.spec.ts
+  artifacts:
+    when: always
+    paths:
+      - test-results/
+      - playwright-report/
+
 git_sizer:
   stage: size_check
   script:

--- a/tests/e2e/character_reroll.spec.ts
+++ b/tests/e2e/character_reroll.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@playwright/test';
+
+// 角色重新投掷直到进入游戏主界面的测试
+
+test('character reroll flow', async ({ page }) => {
+  // 访问首页
+  await page.goto('/');
+
+  // 检查首页按钮文本
+  await expect(page.locator('text=开始游戏')).toBeVisible();
+  await expect(page.locator('text=继续游戏')).toBeVisible();
+  const devBtn = page.locator('text=/开发者(模式|入口)/');
+  if (await devBtn.count()) {
+    await expect(devBtn).toBeVisible();
+  }
+  await expect(page.locator('text=设置')).toBeVisible();
+
+  // 打开并验证设置模态框
+  await page.locator('text=设置').click();
+  await expect(page.locator('#modal')).toBeVisible();
+  await expect(page.locator('#modal-content')).toContainText('游戏设置');
+  await page.evaluate(() => { (window as any).closeModal(); });
+
+  // 开始游戏
+  await page.locator('text=开始游戏').first().click();
+  await page.waitForURL('**/game');
+
+  // 欢迎界面开始游戏
+  const welcomeStart = page.locator('#welcomeModal button:has-text("开始游戏")');
+  if (await welcomeStart.isVisible()) {
+    await welcomeStart.click();
+  }
+
+  // 等待角色创建面板
+  const rollModal = page.locator('#rollModal');
+  await expect(rollModal).toBeVisible();
+
+  // 重新投掷一次并确认
+  const rerollBtn = rollModal.locator('button:has-text("随机生成"), button:has-text("重新投掷")');
+  if (await rerollBtn.isVisible()) {
+    await rerollBtn.click();
+  }
+  await rollModal.locator('button:has-text("确认创建"), button:has-text("踏入此界")').click();
+
+  // 等待进入游戏主界面
+  await expect(rollModal).toBeHidden();
+  await expect(page.locator('#gameContainer')).toBeVisible();
+});

--- a/tests/e2e/playwright.config.ts
+++ b/tests/e2e/playwright.config.ts
@@ -36,7 +36,7 @@ export default defineConfig({
   /* Shared settings for all the projects below */
   use: {
     /* Base URL to use in actions like `await page.goto('/')` */
-    baseURL: process.env.BASE_URL || 'http://localhost:5001',
+    baseURL: process.env.BASE_URL || 'http://localhost:5010',
 
     /* Collect trace when retrying the failed test */
     trace: 'on-first-retry',
@@ -151,8 +151,8 @@ export default defineConfig({
   /* Run your local dev server before starting the tests */
   webServer: {
     // Use the project's run script to start the server
-    command: process.env.CI ? 'python start_web.py' : 'python start_web.py',
-    port: 5001,
+    command: process.env.CI ? 'flask --app src.app:create_app run -p 5010' : 'flask --app src.app:create_app run -p 5010',
+    port: 5010,
     reuseExistingServer: !process.env.CI,
     timeout: 30_000,
     cwd: path.join(__dirname, '..', '..'),
@@ -162,7 +162,7 @@ export default defineConfig({
     env: {
       FLASK_ENV: 'development',
       FLASK_DEBUG: 'False', // Disable debug for testing
-      PORT: '5001',
+      PORT: '5010',
       ENABLE_E2E_API: 'true', // Enable E2E test routes
       PYTHONPATH: path.join(__dirname, '..', '..', 'src'),
     },


### PR DESCRIPTION
## Summary
- add Playwright spec to run through rerolling a new character
- run playwright test in CI
- update Playwright config to use Flask runner on port `5010`

## Testing
- `pytest -k 'nothing'`
- `CI=1 npx playwright test tests/e2e/character_reroll.spec.ts --project=chromium --config=tests/e2e/playwright.config.ts` *(fails: strict mode violation)*

------
https://chatgpt.com/codex/tasks/task_e_6882430c29b88328a106ef13d15f31cb