### PR TITLE
Add developer mode toggle

### DIFF
--- a/src/app/routes/dev.py
+++ b/src/app/routes/dev.py
@@ -21,3 +21,11 @@ def dev_login():
         logger.info("Developer mode enabled via login")
         return jsonify({"success": True})
     return jsonify({"success": False, "error": "Invalid password"}), 401
+
+
+@dev_bp.route("/dev_logout", methods=["POST"])
+def dev_logout():
+    """Disable developer mode by clearing the session flag."""
+    if session.pop("dev", None):
+        logger.info("Developer mode disabled via logout")
+    return jsonify({"success": True})

--- a/src/web/templates/index.html
+++ b/src/web/templates/index.html
@@ -238,7 +238,9 @@
         <div class="actions">
             <a href="/game" class="btn primary">开始游戏</a>
             <a href="#" class="btn" onclick="continueGame(); return false;">继续游戏</a>
-            <a href="/game?mode=dev" class="btn">开发者模式</a>
+            <button class="btn" onclick="toggleDevMode()">
+                {{ 'Exit Developer Mode' if dev_mode else 'Developer Mode' }}
+            </button>
             <button class="btn" onclick="openModal('settings')">设置</button>
         </div>
 
@@ -318,6 +320,42 @@
 
         // 每5秒更新一次
         setInterval(fetchHealth, 5000);
+
+        // 开发者模式切换
+        const DEV_PASSWORD_CONFIGURED = {{ 'true' if dev_password_configured else 'false' }};
+        let DEV_MODE = {{ 'true' if dev_mode else 'false' }};
+
+        function toggleDevMode() {
+            if (DEV_MODE) {
+                fetch('/dev_logout', { method: 'POST' })
+                    .then(() => location.reload())
+                    .catch(() => alert('退出失败'));
+                return;
+            }
+            if (!DEV_PASSWORD_CONFIGURED) {
+                alert('服务器未设置DEV_PASSWORD，无法启用开发者模式');
+                return;
+            }
+            const password = prompt('请输入开发者密码:');
+            if (!password) {
+                return;
+            }
+            fetch('/dev_login', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ password })
+            })
+                .then(resp => resp.json())
+                .then(data => {
+                    if (data.success) {
+                        DEV_MODE = true;
+                        location.reload();
+                    } else {
+                        alert(data.error || '密码错误');
+                    }
+                })
+                .catch(() => alert('开发者模式登录失败'));
+        }
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- allow developers to logout via `/dev_logout`
- add developer mode login/logout UI to `index.html`

## Testing
- `pytest -q` *(fails: 13 failed, 37 passed, 13 skipped, 71 warnings, 12 errors)*

------
https://chatgpt.com/codex/tasks/task_e_688256d68470832882e297da455a0996