### PR TITLE
Fix autosave check in continue route

### DIFF
--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -287,6 +287,8 @@ def continue_game():
         if state:
             game.game_state = state
             instance["need_refresh"] = True
+        else:
+            return redirect(url_for(".intro_screen"))
 
     return redirect(url_for(".game_screen"))
 

--- a/tests/xwe/app/test_continue_game_route.py
+++ b/tests/xwe/app/test_continue_game_route.py
@@ -1,0 +1,24 @@
+import os
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+os.environ['ENABLE_PROMETHEUS'] = 'false'
+from src.app import create_app, game_instances
+
+app = create_app()
+
+
+def test_continue_game_redirects_if_autosave_missing():
+    """When autosave is missing, /continue should redirect to /intro."""
+    with app.test_client() as client:
+        with client.session_transaction() as sess:
+            sess["session_id"] = "test_session"
+
+        game = SimpleNamespace(game_state=SimpleNamespace())
+        game.technical_ops = MagicMock()
+        game.technical_ops.load_game.return_value = None
+        game_instances["test_session"] = {"game": game, "last_update": 0, "need_refresh": False}
+
+        resp = client.get("/continue")
+        assert resp.status_code == 302
+        assert resp.headers["Location"].endswith("/intro")


### PR DESCRIPTION
## Summary
- redirect to intro when autosave file not found
- add regression test for continue route behavior

## Testing
- `pytest tests/xwe/app/test_continue_game_route.py -q`

------
https://chatgpt.com/codex/tasks/task_e_688258c308fc8328b1486250ee0d0fe7