### PR TITLE
Fix metrics port message

### DIFF
--- a/start_xwe.sh
+++ b/start_xwe.sh
@@ -6,6 +6,6 @@ export ENABLE_PROMETHEUS=true
 
 echo "🚀 启动 XianXia World Engine..."
 echo "📊 Prometheus 监控已启用"
-echo "📍 访问 http://localhost:5000/metrics 查看指标"
+echo "📍 访问 http://localhost:5001/metrics 查看指标"
 
 python -m xwe.cli.run_server


### PR DESCRIPTION
## Summary
- use default port 5001 in `start_xwe.sh`

## Testing
- `make test-fast` *(fails: 24 failed, 179 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68825b99d09c8328bba84886db1bfa94