### PR TITLE
Redirect obsolete screen routes

### DIFF
--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -325,12 +325,14 @@ def game_screen():
 
 @main_bp.route("/roll")
 def roll_screen():
-    return render_template("screens/roll_screen.html")
+    """兼容旧路由，重定向至角色创建页面"""
+    return redirect(url_for(".intro_screen"))
 
 
 @main_bp.route("/choose")
 def choose_start():
-    return render_template("screens/choose_start.html")
+    """兼容旧路由，重定向至角色创建页面"""
+    return redirect(url_for(".intro_screen"))
 
 
 @main_bp.route("/modal/<modal_name>")


### PR DESCRIPTION
## Summary
- redirect `/roll` and `/choose` routes to `intro_screen`

## Testing
- `make test-fast` *(fails: 24 failed, 179 passed, 33 skipped, 24 deselected, 42 warnings, 28 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6883450ffc7c8328b7e5a8348fd18d35