### PR TITLE
Show welcome modal on root route

### DIFF
--- a/src/app/__init__.py
+++ b/src/app/__init__.py
@@ -245,9 +245,16 @@ main_bp = Blueprint("main", __name__)
 
 @main_bp.route("/")
 def index():
-    """Landing page with optional developer entry."""
-    dev_mode = is_dev_request() or request.args.get("mode") == "dev"
-    return render_template("index.html", dev_mode=dev_mode)
+    """Landing page showing welcome modal only."""
+    return render_template("start.html")
+
+
+@main_bp.route("/dev_dashboard")
+def dev_dashboard():
+    """Developer dashboard (original index)."""
+    if not session.get("dev"):
+        return redirect(url_for(".index"))
+    return render_template("index.html", dev_mode=True)
 
 
 @main_bp.route("/status")

--- a/src/web/templates/components/command_input.html
+++ b/src/web/templates/components/command_input.html
@@ -196,6 +196,7 @@
  */
 const CommandInput = {
     // 命令示例（用于提示）
+    // TODO: 改为从后端接口加载示例，如 fetch('/api/command/examples')
     examples: [
         { text: '四处看看', desc: '探索当前区域' },
         { text: '随便走走', desc: '闲逛一下' },

--- a/src/web/templates/components/welcome_modal.html
+++ b/src/web/templates/components/welcome_modal.html
@@ -30,9 +30,11 @@
                         <span class="btn-text">继续游戏</span>
                     </button>
 
+                    {% if not dev_mode %}
                     <button class="welcome-btn welcome-btn-dev icon-wrench" onclick="GameLauncher.enterDevMode()">
                         <span class="btn-text">开发者模式</span>
                     </button>
+                    {% endif %}
                 </div>
 
                 <div class="welcome-footer">
@@ -421,7 +423,7 @@ const GameLauncher = {
                     window.DEV_MODE = true;
                     this.initDevConsole();
                     alert('开发者模式已启用！\n- 按F12查看控制台\n- 所有错误将详细显示\n- 可使用调试命令');
-                    this.hide();
+                    window.location.href = '/dev_dashboard';
                 } else {
                     alert(data.error || '密码错误！');
                 }

--- a/src/web/templates/start.html
+++ b/src/web/templates/start.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+
+{% block title %}修仙世界引擎{% endblock %}
+
+{% block content %}
+    {% include "components/welcome_modal.html" %}
+{% endblock %}
+
+{% block extra_js %}
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        if (window.GameLauncher) {
+            window.GameLauncher.show();
+        } else {
+            const modal = document.getElementById('welcomeModal');
+            if (modal) modal.style.display = 'flex';
+        }
+    });
+</script>
+{% endblock %}

--- a/tests/e2e/welcome_dev.spec.ts
+++ b/tests/e2e/welcome_dev.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test';
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:5010';
+
+// Utility to enable dev mode within page context
+async function enableDevMode(page) {
+  await page.goto(`${BASE_URL}/`);
+  await page.evaluate(async () => {
+    await fetch('/dev_login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password: 'test' })
+    });
+  });
+}
+
+test('root shows welcome modal only', async ({ page }) => {
+  const resp = await page.goto(`${BASE_URL}/`);
+  expect(resp?.status()).toBe(200);
+  await expect(page.locator('#welcomeModal')).toBeVisible();
+  await expect(page.locator('text=诊断工具')).toHaveCount(0);
+});
+
+test('dev dashboard after login', async ({ page }) => {
+  await enableDevMode(page);
+  await page.goto(`${BASE_URL}/dev_dashboard`);
+  await expect(page.locator('text=诊断工具')).toBeVisible();
+});

--- a/tests/web/test_root_welcome.py
+++ b/tests/web/test_root_welcome.py
@@ -1,0 +1,17 @@
+import pytest
+from src.app import create_app
+
+@pytest.fixture
+def app_instance():
+    app = create_app()
+    app.config.update(TESTING=True, DEV_PASSWORD='test')
+    return app
+
+
+def test_root_contains_welcome_modal(app_instance):
+    with app_instance.test_client() as client:
+        resp = client.get('/')
+        assert resp.status_code == 200
+        data = resp.data.decode('utf-8')
+        assert 'welcomeModal' in data
+        assert '诊断工具' not in data


### PR DESCRIPTION
## Summary
- default landing page renders welcome modal only
- enable developer dashboard at `/dev_dashboard`
- hide developer-mode button when already enabled
- note TODO to load command hints from API
- add end-to-end and unit tests for new behaviour

## Testing
- `pytest tests/web/test_root_welcome.py::test_root_contains_welcome_modal -v`
- `DEV_PASSWORD=test CI=true npx playwright test tests/e2e/welcome_dev.spec.ts --config=tests/e2e/playwright.config.ts --project=chromium --timeout=60000`


------
https://chatgpt.com/codex/tasks/task_e_6883558abf7083288c2dee721da7850b