### PR TITLE
Skip stress modules and concurrent tests

### DIFF
--- a/tests/benchmark/test_nlp_performance.py
+++ b/tests/benchmark/test_nlp_performance.py
@@ -143,6 +143,7 @@ class TestNLPPerformance:
                 assert case['compression_ratio'] < 0.7  # 中等对话应该有30%以上的压缩率
     
     @pytest.mark.asyncio
+    @pytest.mark.skip(reason="single-player")
     async def test_async_vs_sync_performance(self):
         """异步 vs 同步性能对比"""
         from xwe.core.nlp.llm_client import LLMClient
@@ -276,6 +277,7 @@ class TestNLPPerformance:
         # 生成对比图表
         self._generate_performance_chart(results)
     
+    @pytest.mark.skip(reason="single-player")
     def test_resource_monitoring(self, nlp_processor):
         """测试资源使用监控"""
         import threading

--- a/tests/e2e/test_nlp_e2e.py
+++ b/tests/e2e/test_nlp_e2e.py
@@ -145,6 +145,7 @@ class TestNLPEndToEnd:
                     assert compression_ratio < 0.8  # 至少20%的压缩率
     
     @pytest.mark.slow
+    @pytest.mark.skip(reason="single-player")
     def test_concurrent_users(self, app):
         """测试并发用户（10+ 并发）"""
         from xwe.core.nlp.nlp_processor import NLPProcessor

--- a/tests/integration/test_deepseek_async.py
+++ b/tests/integration/test_deepseek_async.py
@@ -159,6 +159,7 @@ class TestDeepSeekAsyncIntegration:
         logger.info(f"Average time per request: {duration/len(test_prompts):.2f}s")
     
     @pytest.mark.asyncio
+    @pytest.mark.skip(reason="single-player")
     async def test_concurrent_requests(self, client):
         """Test multiple concurrent requests."""
         num_requests = 10
@@ -249,6 +250,8 @@ class TestPerformanceComparison:
             logger.info(f"Speedup: {sync_duration/async_duration:.1f}x")
 
 
+@pytest.mark.asyncio
+@pytest.mark.skip(reason="single-player")
 @pytest.mark.asyncio
 async def test_stress_test():
     """Stress test with high concurrency."""

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -225,8 +225,8 @@ def main():
     parser.add_argument(
         'test_type',
         choices=[
-            'unit', 'integration', 'e2e', 'performance', 
-            'stress', 'regression', 'all', 'quick', 
+            'unit', 'integration', 'e2e', 'performance',
+            'regression', 'all', 'quick',
             'coverage', 'clean'
         ],
         help='测试类型'
@@ -275,8 +275,6 @@ def main():
         return runner.run_e2e_tests()
     elif args.test_type == 'performance':
         return runner.run_performance_tests()
-    elif args.test_type == 'stress':
-        return runner.run_stress_tests()
     elif args.test_type == 'regression':
         return runner.run_regression_tests()
     elif args.test_type == 'all':

--- a/tests/stress/locustfile.py
+++ b/tests/stress/locustfile.py
@@ -3,6 +3,9 @@ Locust 压力测试脚本
 用于模拟大量并发用户
 """
 
+import pytest
+pytest.skip("stress tests disabled", allow_module_level=True)
+
 from locust import HttpUser, task, between, events
 import json
 import random

--- a/tests/stress/test_nlp_stress.py
+++ b/tests/stress/test_nlp_stress.py
@@ -4,6 +4,7 @@
 """
 
 import pytest
+pytest.skip("stress tests disabled", allow_module_level=True)
 import time
 import os
 import sys

--- a/tests/xwe/core/nlp/test_deepseek_async.py
+++ b/tests/xwe/core/nlp/test_deepseek_async.py
@@ -112,6 +112,7 @@ class TestDeepSeekAsyncClient:
             assert "禁止使用禁术" in call_args
     
     @pytest.mark.asyncio
+    @pytest.mark.skip(reason="single-player")
     async def test_concurrent_requests(self, client):
         """Test multiple concurrent async requests."""
         mock_response = {
@@ -227,6 +228,7 @@ class TestDeepSeekClientIntegration:
         assert len(result["text"]) > 0
     
     @pytest.mark.asyncio
+    @pytest.mark.skip(reason="single-player")
     async def test_performance_comparison(self):
         """Compare performance of sync vs async methods."""
         import time

--- a/tests/xwe/core/nlp/test_nlp_processor.py
+++ b/tests/xwe/core/nlp/test_nlp_processor.py
@@ -202,6 +202,7 @@ class TestNLPProcessor:
         assert len(results) == 10
         assert all(r is not None for r in results)
     
+    @pytest.mark.skip(reason="single-player")
     def test_concurrent_processing(self, nlp_processor):
         """测试并发处理"""
         import threading


### PR DESCRIPTION
## Summary
- disable stress test modules at import
- skip concurrency-heavy tests in integration, e2e, unit, and benchmarks
- remove stress option from helper script

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: errors during tests)*

------
https://chatgpt.com/codex/tasks/task_e_68844e0152dc8328b8e7267522db9df6