### PR TITLE
Remove mock LLM docs

### DIFF
--- a/infrastructure/deploy/verification_checklist.md
+++ b/infrastructure/deploy/verification_checklist.md
@@ -19,7 +19,6 @@
   export DEEPSEEK_API_KEY="your-api-key"
   export ENABLE_PROMETHEUS="true"
   export ENABLE_CONTEXT_COMPRESSION="true"
-  export USE_MOCK_LLM="false"  # 生产环境设为 false
   export XWE_MAX_LLM_RETRIES="3"
   export LLM_ASYNC_WORKERS="5"
   ```

--- a/src/xwe/metrics/PROMETHEUS_README.md
+++ b/src/xwe/metrics/PROMETHEUS_README.md
@@ -29,7 +29,6 @@ http://localhost:5000/metrics
 ### 环境变量
 
 - `ENABLE_PROMETHEUS`: 设置为 `true` 启用 Prometheus 指标（默认：true）
-- `USE_MOCK_LLM`: 设置为 `true` 使用模拟 LLM（用于测试）
 - `XWE_MAX_LLM_RETRIES`: LLM API 最大重试次数（默认：3）
 - `LLM_ASYNC_WORKERS`: 异步线程池大小（默认：5）
 


### PR DESCRIPTION
## Summary
- remove `USE_MOCK_LLM` instructions from Prometheus metrics docs
- remove `USE_MOCK_LLM` setup line from deploy checklist

## Testing
- `make test-fast` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68844faf7fec8328bac0d77eef111c31