### PR TITLE
Expose create_app from scripts/run

### DIFF
--- a/scripts/run.py
+++ b/scripts/run.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 """兼容旧路径的启动脚本"""
 from src.xwe.cli.run_server import main, app, get_game_instance
+from src.xwe.app import create_app  # 新增
+
+__all__ = ["main", "app", "get_game_instance", "create_app"]
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Summary
- import `create_app` in `scripts/run.py`
- add `create_app` to module exports via `__all__`

## Testing
- `pytest -q` *(fails: fixture 'client' not found)*

------
https://chatgpt.com/codex/tasks/task_e_688461df9d148328b0510c7ec69b00c2